### PR TITLE
Robuster implementation of dimensionality reduction using sklearn (#46)

### DIFF
--- a/toxicity/notebooks/dimensionality_reduction.ipynb
+++ b/toxicity/notebooks/dimensionality_reduction.ipynb
@@ -6,15 +6,24 @@
    "source": [
     "# Dimensionality Reduction\n",
     "\n",
-    "In this notebook we will explore how [gensim](https://github.com/RaRe-Technologies/gensim) can be used within a supervised machine learning context. Concretely, we can use the topic modeling tools included in the package to reduce the dimensionality\n",
+    "In this notebook we use gensim and sklearn to reduce the dimensionality\n",
     "of our (extremely sparse and wide) input."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\s100385\\Anaconda3\\lib\\site-packages\\gensim\\utils.py:1167: UserWarning: detected Windows; aliasing chunkize to chunkize_serial\n",
+      "  warnings.warn(\"detected Windows; aliasing chunkize to chunkize_serial\")\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -27,6 +36,8 @@
     "from preprocessing import *\n",
     "from utils import *\n",
     "\n",
+    "import nltk\n",
+    "\n",
     "DATA_ROOT = \"../data/\"\n",
     "\n",
     "train = pd.read_csv(\"../data/train.csv\")\n",
@@ -35,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -57,19 +68,34 @@
     "This will take a lot of time to run (around 20 minutes total on my machine). This is because the algorithms comprises of \n",
     "several computationally expensive steps:\n",
     "\n",
-    "1. Tokenize text.\n",
+    "1. Tokenize text using NLTK's tokenizer.\n",
     "2. Create the train and test corpora.\n",
     "3. Get the TFIDF sparse representations.\n",
-    "4. Apply dimensionality reduction using LSA or LDA both of which are optimized but still demanding."
+    "4. Apply dimensionality reduction using Latent Semantic Analysis (LSA)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating TF-IDF model and representations..\n"
+     ]
+    }
+   ],
    "source": [
-    "train_x, test_x = gensim_preprocess(train, test, model_type='lsi', num_topics=500, report_progress=True, data_dir=DATA_ROOT)"
+    "train_x, test_x = truncatedSVD_preprocess(train, test, num_topics=500, report_progress=True, data_dir='data/', save=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create TF-IDF model from the sklearn package and fit it to the whole corpus."
    ]
   },
   {
@@ -148,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/toxicity/notebooks/dimensionality_reduction.ipynb
+++ b/toxicity/notebooks/dimensionality_reduction.ipynb
@@ -12,18 +12,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\s100385\\Anaconda3\\lib\\site-packages\\gensim\\utils.py:1167: UserWarning: detected Windows; aliasing chunkize to chunkize_serial\n",
-      "  warnings.warn(\"detected Windows; aliasing chunkize to chunkize_serial\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -32,7 +23,7 @@
     "sys.path.append(\"..\") # Append source directory to our Python path\n",
     "\n",
     "from predictor import Predictor\n",
-    "from linear_predictor import LogisticPredictor\n",
+    "from linear_predictor import LogisticPredictor, SVMPredictor\n",
     "from preprocessing import *\n",
     "from utils import *\n",
     "\n",
@@ -46,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -78,24 +69,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating TF-IDF model and representations..\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "train_x, test_x = truncatedSVD_preprocess(train, test, num_topics=500, report_progress=True, data_dir='data/', save=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create TF-IDF model from the sklearn package and fit it to the whole corpus."
    ]
   },
   {
@@ -116,15 +92,11 @@
    "outputs": [],
    "source": [
     "# Create a logistic regression classifier.\n",
-    "lr_params = {\"C\": 4, \"dual\": True}\n",
-    "predictor = LogisticPredictor(**lr_params)\n",
+    "svm_params = {\"C\": 1, \"dual\": True}\n",
+    "predictor = SVMPredictor(**svm_params)\n",
     "\n",
-    "# We are currently supporting 3 evaluation methods, stratified CV, random CV and split. Lets check them.\n",
-    "stratified_cv_loss = predictor.evaluate(train_x, train_ys, method='stratified_CV')\n",
-    "cv_loss = predictor.evaluate(train_x, train_ys, method='CV')\n",
     "split_loss = predictor.evaluate(train_x, train_ys, method='split')\n",
-    "\n",
-    "print(\"CV Stratified CV log loss: {}\\nCV log loss: {}\\nSplit CV log loss: {}\".format(stratified_cv_loss, cv_loss, split_loss))"
+    "print(\"Split CV log loss: {}\".format(split_loss))"
    ]
   },
   {

--- a/toxicity/preprocessing.py
+++ b/toxicity/preprocessing.py
@@ -36,6 +36,7 @@ def remove_numbers(train, test):
     return train, test
 
 
+@check_compatibility
 @timing
 def gensim_preprocess(train, test, model_type='lsi', num_topics=500,
                       use_own_tfidf=False, force_compute=False, report_progress=False,
@@ -166,23 +167,16 @@ def gensim_preprocess(train, test, model_type='lsi', num_topics=500,
 
     # Transform into a 2D array format.
     print("Reformatting output to a 2D array, this will take a while...")
-    
-    def safe_get(x):
-        print(x)
-        try:
-            return x[1]
-        except IndexError:
-            return np.zeros(num_topics)
-
-    values = np.vectorize(safe_get)
+    values = np.vectorize(lambda x: x[1])
     return values(np.array(train)), values(np.array(test))
+
 
 @check_compatibility
 @timing
-def truncatedSVD_preprocess(train, test, num_topics=500, report_progress=False,
+def truncatedsvd_preprocess(train, test, num_topics=500, report_progress=False,
                             data_dir='data/', save=False):
 
-    """ Use Latent Semantic Analysis (LSA/LSI) to a dense matrix representation of the input text.
+    """ Use Latent Semantic Analysis (LSA/LSI) to obtain a dense matrix representation of the input text.
 
     Parameters
     ----------

--- a/toxicity/preprocessing.py
+++ b/toxicity/preprocessing.py
@@ -233,9 +233,12 @@ def truncatedSVD_preprocess(train, test, num_topics=500, report_progress=False,
     x_test = svd.transform(test_tfidf)
 
     # save and return data
+    x_train = pd.DataFrame(x_train)
+    x_test = pd.DataFrame(x_test)
+
     if save:
-        np.save(data_dir+"train_"+str(int(num_topics)), x_train)
-        np.save(data_dir+"test_"+str(int(num_topics)), x_test)
+        x_train.to_csv(data_dir+"train_"+str(int(num_topics)))
+        x_test.to_csv(data_dir+"test_"+str(int(num_topics)))
 
     progress("Dimensionality reduction completed.")
     return x_train, x_test


### PR DESCRIPTION
Added a separate function that performs TF-IDF and dimensionality reduction using sklearn's methods. The problem seemed to be in the TF-IDF representations from our former methods, so replacing that as well solves the issue. The function still uses the NLTK tokenizer.

We might want to extend this function later on to make it a bit more flexible, e.g. with different tokenizers, stop word filters, etc..