### PR TITLE
Ensure train-test split is maintained correctly (fixes #94)

### DIFF
--- a/google_analytics/preprocessing.py
+++ b/google_analytics/preprocessing.py
@@ -46,6 +46,9 @@ def process(train, test):
     train_len = train.shape[0]
     merged = pd.concat([train, test], sort=False)
 
+    # Ensure correct train-test split
+    merged["manual_index"] = np.arange(0, len(merged))
+
     # Change values as "not available in demo dataset", "(not set)",
     # "unknown.unknown", "(not provided)" to nan.
     list_missing = ["not available in demo dataset", "(not provided)",
@@ -93,6 +96,7 @@ def process(train, test):
     merged = merged.merge(total_visits)
 
     print("Splitting back...")
+    merged.sort_values(by="manual_index", ascending=True, inplace=True)
     train = merged[:train_len]
     test = merged[train_len:]
     return train, test


### PR DESCRIPTION
Order of train and test records was not maintained during preprocessing, leading to records of the train set ending up in the test set and vice versa. I added a manual index right after concatenating the data and sort by that index before splitting to ensure the order - and thus the split - remains intact.