### PR TITLE
added statistics on single visit users - should they be ignored?

### DIFF
--- a/google_analytics/notebooks/load.ipynb
+++ b/google_analytics/notebooks/load.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,24 +34,189 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded file ../data/train.csv\n",
+      "Shape is: (903653, 55)\n"
+     ]
+    }
+   ],
    "source": [
-    "train = load(\"../data/train.csv\", nrows=100000)\n",
-    "test = load(\"../data/test.csv\", nrows=10000)\n",
+    "train = load(\"../data/train.csv\")\n",
     "\n",
-    "# preprocess_and_save(\"../data\", nrows_train=100000, nrows_test=10000)\n",
-    "train, test = process(train, test)"
+    "const_cols = [c for c in train.columns if train[c].nunique(dropna=False) == 1]\n",
+    "train = train.drop(const_cols, axis=1)\n",
+    "\n",
+    "# Cast target\n",
+    "train[\"transactionRevenue\"] = train[\"transactionRevenue\"].fillna(0).astype(float)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hypothesis: certain profiles should be naively assigned a zero predicted revenue\n",
+    "\n",
+    "Since the new problem description includes much less information at prediction time (no session info) it might be beneficial to only focus on visitors with a high probability to spend - and assign a zero prediction to everyone else.\n",
+    "\n",
+    "**Which profile is improbable enough to make a purchase, that it makes sense to make that prediction naively?**\n",
+    "\n",
+    "We think that visitors with a single visit that did not lead to a purchase during the training period (prior to December of the testing year) have a very high probability of not buying anything during December and January either. Let's test this assumption."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
-    "preprocess_and_save(\"../data\", nrows_train=100000, nrows_test=10000)"
+    "x_train = train[(train[\"date\"] < '2016-12-01')]\n",
+    "y_train = train[(train[\"date\"] >= '2016-12-01') & (train[\"date\"] >= '2017-02-01')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 263866 such visitors (out of 295432 found in our training set in total).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Find people with a single visit during the training period\n",
+    "count = x_train[[\"fullVisitorId\", \"transactionRevenue\"]].groupby(\"fullVisitorId\").count().reset_index()\n",
+    "\n",
+    "single_visit_ids = count[count[\"transactionRevenue\"] == 1][\"fullVisitorId\"]\n",
+    "print(\"There are {} such visitors (out of {} found in our training set in total).\".format(len(single_visit_ids), len(count)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out of 263866 single visits, 1107 ended up in a purchase\n"
+     ]
+    }
+   ],
+   "source": [
+    "# But maybe some of those guys actually bought something in that single visit.\n",
+    "single_visits = x_train[x_train[\"fullVisitorId\"].isin(single_visit_ids)]\n",
+    "num_purchases = len(single_visits[single_visits[\"transactionRevenue\"] > 0][\"transactionRevenue\"])\n",
+    "print(\"Out of {} single visits, {} ended up in a purchase\".format(len(single_visit_ids), num_purchases))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We will therefore choose to ignore 262759 users\n"
+     ]
+    }
+   ],
+   "source": [
+    "to_ignore = set(single_visit_ids) - set(single_visits[single_visits[\"transactionRevenue\"] > 0][\"fullVisitorId\"])\n",
+    "print(\"We will therefore choose to ignore {} users\".format(len(to_ignore)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Is this assumption justified?\n",
+    "\n",
+    "How reliable is this assumption? Are these people that we choose to ignore indeed buying nothing? Let's find out.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 2290 people appearing both in the training and the test periods\n",
+      "We will ignore 2037 out of those 2290 people\n"
+     ]
+    }
+   ],
+   "source": [
+    "# We will only focus on people who exist in both datasets\n",
+    "common_ids = set(y_train[\"fullVisitorId\"]).intersection(x_train[\"fullVisitorId\"])\n",
+    "print(\"There are {} people appearing both in the training and the test periods\".format(len(common_ids)))\n",
+    "\n",
+    "y_train = y_train[y_train[\"fullVisitorId\"].isin(common_ids)]\n",
+    "ignored = y_train[y_train[\"fullVisitorId\"].isin(to_ignore)]\n",
+    "print(\"We will ignore {} out of those {} people\".format(len(ignored), len(common_ids)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We made 196 mistakes (9.62% of cases) leading to loss = 5.4433800738203315\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "predicted_target = [0] * len(common_ids)\n",
+    "\n",
+    "y_train_grouped = y_train[[\"fullVisitorId\", \"transactionRevenue\"]].groupby(\"fullVisitorId\", as_index=False).sum()\n",
+    "actual_target = y_train_grouped[\"transactionRevenue\"].apply(lambda revenue: np.log(revenue + 1))\n",
+    "    \n",
+    "loss = np.sqrt(np.mean((predicted_target - actual_target)**2))\n",
+    "num_mistakes = sum(actual_target > 0)\n",
+    "\n",
+    "print(\"We made {} mistakes ({:.2f}% of cases) leading to loss = {}\".format(num_mistakes, 100*num_mistakes/len(ignored) ,loss))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Is this small enough?\n",
+    "\n",
+    "That's not a neglilible mistake: 196 out of 2037 people and a loss of 5 in the log space. However we do not yet know what a predictive model would be able to predict (without any session information of course). If a model would be able to do better, then its of course a bad idea to ignore these guys. If the predictive model fails, then its a good idea to ignore them.\n",
+    "\n",
+    "**To be continued!**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run this if you need to recreate the initial dataset\n",
+    "#preprocess_and_save(\"../data\", nrows_train=100000, nrows_test=10000)"
    ]
   },
   {
@@ -65,19 +230,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded file ../data/train.csv\n",
+      "Shape is: (903653, 55)\n",
+      "Loaded file ../data/test.csv\n",
+      "Shape is: (10000, 53)\n",
+      "Dropping constant columns...\n",
+      "Create some features...\n",
+      "Generating date columns...\n",
+      "Finding total visits...\n",
+      "Splitting back...\n",
+      "There are 222 different countries in our dataset\n"
+     ]
+    }
+   ],
    "source": [
+    "train = load(\"../data/train.csv\")\n",
+    "test = load(\"../data/test.csv\", nrows=10000)\n",
+    "train, test = process(train, test)\n",
+    "\n",
     "countries = train['country']\n",
     "print(\"There are {} different countries in our dataset\".format(len(countries.unique())))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1cb59571cf8>"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX8AAAFQCAYAAABXvn6EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3XucHFWZ//HPl1wMGC4CUYGQBJFFEEw0w0WRcL8pBl1BYHEBFQIiKy7LLiguxqgr4mVXkZ8YQEBEgiBgQFh2CXcQTAIJEAJyVWZBgaDIJcGEPL8/TnXoTHomYbrnVNP1fb9eeU13dXWdZyY9z1SdOuc5igjMzKxaVis7ADMzy8/J38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqaHDZAfRm/fXXjzFjxpQdhpnZG8rs2bOfjYgRK9uvbZP/mDFjmDVrVtlhmJm9oUj6/ars524fM7MKcvI3M6sgJ38zswpq2z5/M+tcixcvpru7m0WLFpUdyhvWsGHDGDlyJEOGDOnX+538zSy77u5u1lxzTcaMGYOkssN5w4kIFixYQHd3N5tsskm/juFuHzPLbtGiRay33npO/P0kifXWW6+pKycnfzMrhRN/c5r9+bUk+UvaW9KDkh6WdFKD14+WdK+kOZJulbRlK9o1M7P+abrPX9Ig4AxgD6AbmClpekTcX7fbzyPizGL/icD3gL2bbXvMSb9u9hA8fuqHmz6GmTWnFb/L9V7v7/XkyZMZPnw4J5xwwut63ymnnMKECRPYfffde93nvPPOY88992TDDTcE4IgjjuD4449nyy3LPQduxQ3fbYGHI+JRAEnTgP2AZck/Iv5at/+bAa8ab2ZveFOmTFnpPueddx5bbbXVsuR/9tlnD3RYq6QV3T4bAU/UPe8uti1H0uckPQKcBny+Be2amfXbN77xDTbffHN23313HnzwQQAeeeQR9t57b8aPH8+OO+7IAw88wPPPP8+YMWNYunQpAC+//DIbb7wxixcv5vDDD+fSSy8F0h+CbbbZhq222opJkyYREVx66aXMmjWLQw45hHHjxrFw4UJ23nnnZaVrLrroIrbeemu22morTjzxxGWxDR8+nJNPPpmxY8ey/fbb86c//anl338rkn+juw4rnNlHxBkRsSlwIvDlhgeSJkmaJWnWM88804LQzMxWNHv2bKZNm8bdd9/NZZddxsyZMwGYNGkSp59+OrNnz+Y73/kOxxxzDGuvvTZjx47lpptuAuDKK69kr732WmF8/bHHHsvMmTO57777WLhwIVdddRX7778/XV1dXHjhhcyZM4fVV1992f5PPvkkJ554Itdffz1z5sxh5syZXHHFFQC89NJLbL/99sydO5cJEyZw1llntfxn0Irk3w1sXPd8JPBkH/tPAz7a6IWImBoRXRHRNWLESovSmZn1yy233MLHPvYx1lhjDdZaay0mTpzIokWLuP322znggAMYN24cRx11FE899RQABx54IBdffDEA06ZN48ADD1zhmDfccAPbbbcdW2+9Nddffz3z5s3rM4aZM2ey8847M2LECAYPHswhhxzCzTffDMDQoUPZd999ARg/fjyPP/54C7/7pBV9/jOBzSRtAvwfcBDwD/U7SNosIh4qnn4YeAgzsxL1HCq5dOlS1llnHebMmbPCvhMnTuSLX/wizz33HLNnz2bXXXdd7vVFixZxzDHHMGvWLDbeeGMmT5680jH4Eb3f+hwyZMiy+AYNGsSSJUtW9dtaZU2f+UfEEuBY4FpgPvCLiJgnaUoxsgfgWEnzJM0BjgcOa7ZdM7P+mjBhApdffjkLFy7khRde4Morr2SNNdZgk0024ZJLLgFScp47dy6Q+uC33XZbjjvuOPbdd18GDRq03PFqiX799dfnxRdfXHYfAGDNNdfkhRdeWCGG7bbbjptuuolnn32WV199lYsuuoiddtppoL7lFbSkvENEXA1c3WPbKXWPj2tFO2bWmXIPuX7f+97HgQceyLhx4xg9ejQ77rgjABdeeCGf/exn+frXv87ixYs56KCDGDt2LJC6fg444ABuvPHGFY63zjrrcOSRR7L11lszZswYttlmm2WvHX744Rx99NGsvvrq/OY3v1m2fYMNNuCb3/wmu+yyCxHBhz70Ifbbb7+B/cbrqK9LjzJ1dXXFyhZz8Th/szem+fPns8UWW5Qdxhteo5+jpNkR0bWy97q8g5lZBTn5m5lVkJO/mZWiXbuc3yia/fk5+ZtZdsOGDWPBggX+A9BPtXr+w4YN6/cxvJiLmWU3cuRIuru78Uz+/qut5NVfTv5mlt2QIUP6vQKVtYa7fczMKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqqCXJX9Lekh6U9LCkkxq8fryk+yXdI2mGpNGtaNfMzPqn6eQvaRBwBrAPsCVwsKQte+x2N9AVEe8BLgVOa7ZdMzPrv1ac+W8LPBwRj0bE34BpwH71O0TEDRHxcvH0DmBkC9o1M7N+akXy3wh4ou55d7GtN58BrmlBu2Zm1k+DW3AMNdgWDXeUPgl0ATv18vokYBLAqFGjWhCamZk10ooz/25g47rnI4Ene+4kaXfgZGBiRLzS6EARMTUiuiKia8SIES0IzczMGmlF8p8JbCZpE0lDgYOA6fU7SHov8GNS4n+6BW2amVkTmk7+EbEEOBa4FpgP/CIi5kmaImlisdu3geHAJZLmSJrey+HMzCyDVvT5ExFXA1f32HZK3ePdW9GOmZm1hmf4mplVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQW1JPlL2lvSg5IelnRSg9cnSLpL0hJJ+7eiTTMz67+mk7+kQcAZwD7AlsDBkrbssdsfgMOBnzfbnpmZNW9wC46xLfBwRDwKIGkasB9wf22HiHi8eG1pC9ozM7MmtaLbZyPgibrn3cU2MzNrU61I/mqwLfp1IGmSpFmSZj3zzDNNhmVmZr1pRfLvBjauez4SeLI/B4qIqRHRFRFdI0aMaEFoZmbWSCuS/0xgM0mbSBoKHARMb8FxzcxsgDSd/CNiCXAscC0wH/hFRMyTNEXSRABJ20jqBg4AfixpXrPtmplZ/7VitA8RcTVwdY9tp9Q9nknqDjIzszbgGb5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQS1J/pL2lvSgpIclndTg9TdJurh4/U5JY1rRrpmZ9U/TyV/SIOAMYB9gS+BgSVv22O0zwJ8j4p3AfwLfarZdMzPrv1ac+W8LPBwRj0bE34BpwH499tkPOL94fCmwmyS1oG0zM+uHViT/jYAn6p53F9sa7hMRS4DngfVa0LaZmfXD4BYco9EZfPRjHyRNAiYBjBo1aqUNP37qh1chvAE2ee0WHOP5pg+x9flbN32Mew+7t6n3z3/XFk3HsMUD85s+xhlHX9/U+z935q5Nx/DdA/dt+hj/cvFVTR+j+6Rbmnr/yFN3bDqGyZMnt8UxZly/aVPv323XR5qO4e03zGn6GH/cZVzTx4DWnPl3AxvXPR8JPNnbPpIGA2sDz/U8UERMjYiuiOgaMWJEC0IzM7NGWpH8ZwKbSdpE0lDgIGB6j32mA4cVj/cHro+IFc78zcwsj6a7fSJiiaRjgWuBQcBPImKepCnArIiYDpwDXCDpYdIZ/0HNtmtmZv3Xij5/IuJq4Ooe206pe7wIOKAVbZmZWfM8w9fMrIKc/M3MKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqqKnkL2ldSf8r6aHi61t62e+/Jf1F0lXNtGdmZq3R7Jn/ScCMiNgMmFE8b+TbwD822ZaZmbXI4Cbfvx+wc/H4fOBG4MSeO0XEDEk799xunWWLB+aXHYKZraJmz/zfFhFPARRf39p8SGZmNtBWeuYv6Trg7Q1eOrnVwUiaBEwCGDVqVKsPb2ZmhZUm/4jYvbfXJP1J0gYR8ZSkDYCnmwkmIqYCUwG6urqimWOZmVnvmu32mQ4cVjw+DPhVk8czM7MMmk3+pwJ7SHoI2KN4jqQuSWfXdpJ0C3AJsJukbkl7NdmumZk1oanRPhGxANitwfZZwBF1z3dsph0zM2stz/A1M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCmoq+UtaV9L/Snqo+PqWBvuMk/QbSfMk3SPpwGbaNDOz5jV75n8SMCMiNgNmFM97ehk4NCLeDewN/JekdZps18zMmtBs8t8POL94fD7w0Z47RMTvIuKh4vGTwNPAiCbbNTOzJjSb/N8WEU8BFF/f2tfOkrYFhgKPNNmumZk1YfDKdpB0HfD2Bi+d/HoakrQBcAFwWEQs7WWfScAkgFGjRr2ew5uZ2euw0uQfEbv39pqkP0naICKeKpL7073stxbwa+DLEXFHH21NBaYCdHV1xcpiMzOz/mm222c6cFjx+DDgVz13kDQUuBz4aURc0mR7ZmbWAs0m/1OBPSQ9BOxRPEdSl6Szi30+AUwADpc0p/g3rsl2zcysCSvt9ulLRCwAdmuwfRZwRPH4Z8DPmmnHzKwT/HGX9jnv9QxfM7MKaurM38zsjWK3XT3CvJ6Tf4e497B7yw7BrKHJkyeXHYI14OTfrMnPlx2BWa9Gnrpj2SFYm3LyNxsA/3LxVWWHYNYnJ3/rOJ87c9eyQzBrex7tY2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBimjP1RIlPQP8vsnDrA8824JwmtUOcbRDDNAecbRDDNAecbRDDNAecbRDDNB8HKMjYsTKdmrb5N8KkmZFRJfjaI8Y2iWOdoihXeJohxjaJY52iCFnHO72MTOrICd/M7MK6vTkP7XsAArtEEc7xADtEUc7xADtEUc7xADtEUc7xACZ4ujoPn8zM2us08/8zcysASd/M7MK6tiVvCStBgyPiL+WHUsZJA0CPgyMoe7/OSK+V1ZMVSbpTuAnwEVlfCYlva+v1yPirlyxWHvoqOQv6efA0cCrwGxgbUnfi4hvlxtZKa4EFgH3AktLjgVJbwWG1Z5HxB9KiGEtlv9D+FzG5g8DPgXMkXQ7cG5EzMjY/neLr8OALmAuIOA9wJ3ABzPGgqTvkH4G83K2W9f+un29nuuzIWkHYDIwmvTZVGo+3jHgbXfSDV9JcyJinKRDgPHAicDsiHhPCbGMKNrfkuWTXpYFZiXdU8b33SCOiaTEsyHwNOlDPj8i3p0xhqOAKcBCoPaBz/IL1iCWQcBE4IfA30hXA6dHxF8ytT8N+EZE3Fs83wo4ISIOz9F+XRxHkP4YDgbOJV0RPZ+x/cdInwU1eDnbZ0PSA8A/k05WX60LYMFAt91RZ/7AEElDgI8CP4yIxZLK+ut2IXAxqevlaNKZ3zMZ279G0p4R8T8Z22zka8D2wHUR8V5JuwAHZ47hBODdEVHq1H1JW5IS3keAX5E+Ix8Ergf67JZpoXfVEj9ARNwnaVymtpeJiLOBsyVtTvqZ3CPpNuCsiLghQ/ubDHQbq+j5iLimjIY7Lfn/GHicdEl7s6TRQFl9/utFxDmSjouIm4CbJN2Usf07gMuLex+Lee1ycq2MMQAsjogFklaTtFpE3CDpW5ljeAR4OXObyyn6/BeSzvRPiYiFxUu3FZf+ucyXdDbwM9KZ7yeB+RnbX6a4CnpX8e9Z0u/t8ZKOioiDBrjtd0XEA73dC8l4D+QGSd8GLgNeydl+R3X7NCJpcEQsKaHdOyJie0nXAj8AngQujYhNM7X/KOkK6N4o8T9Z0nVFHN8kFax6GtgmIj6QMYb3kroW7mT5X7DPZ4zh7yLid7na6yOOYcBngQnFppuBH0XEosxxfI/U/TUDOCciflv32oMRsfkAtz81IiZJanSVERm7Z0trv6OSv6S3Af8BbBgR+xSX2e+PiHNKiGVf4BZgY+B0YC3gqxExPVP71wL7RESpN3slvZl041nAIcDawIU5+jTrYvgtcCs9bn5HxPkZYxgBfB3YKCL2LT6b20bEebliaCeSPg1Mi4gVrsgkrZ2z/7+qOi35X0M6wzs5IsZKGgzcHRFblxxadpLOA94BXMPyZ7uVG+op6facVxq9xPBrUh//icVncwhwV+7PZoPRJQCUdPN7owZx3Jw5hkeAb0fEmXXbroqIfTPG8GHg3Sw/MGTKQLfbaX3+60fELyR9ESAilkh6dWVvaiVJ/xYRp0k6nddGliyTsavhseLf0OJfVpJeoMH3X5P53sMNkiaRhr/W/yHMOdTzrRHxc0n/WrS9OPdns3AODUaX5CbpVOAg4P66OILUDZXTYmAXSdsBR0XE34CNcjUu6UxgDWAX4Gxgf+C3fb6pRTot+b8kaT2KpCNpeyD35WPt5tmszO0uJyK+CiBpzfQ0Xszc/ppF+1OAPwIX8FrXz5o5YwH+ofj6xbptQboyyuWlYmx57bO5DfBCxvZrShtd0sPHgM0j4pWV7jmwXo6IAyX9G3CLpE/Qx0nLAPhARLynGJr9VUnfJd38HXCdlvyPB6YDmxbDxkYAB+QMICKuLL5m609upBi/fQGwbvH8WeDQEibV7BUR29U9/1Ex8uW0XAG0ybC+E0hXHu8oRn1tRDrLy6200SU9PAoMqY+hJAIortZnA9dS/M5kUhv19bKkDYEFQJbPa6cl/3nATsDmpP/UB8lcv0jSlfTd3TExUyhTgeNrY6Yl7QycBeTu+361mHQ3jfRzOZgSuhuKP4Y9J9z9NFf7ETGrmOOwBemzeX+utnuo/SGuXykqgCyjW+q8TJrtPIOSRmAVTqlre4akPYHDM7Z/laR1gG8Dd5H+L87K0XCn3fC9KyLet7JtAxzDTsXDvwfeThpPDSnpPR4RX8oUx9yIGLuybRniGAN8H9iB9MG+DfhCRDyeMYavADuTkv/VwD7ArRGR7cxb0lkRcWTd8zWAX0XEHrliaCeSDmu0vYwrZklvATZj+ROD3PcekPQmYFiukU4dceYv6e2ky+jVizHdtSnba5FupmRTTOhC0tciYkLdS1dKyvmBelTSv5O6fiBN5nksY/sAFEl+v9zt9rA/MJY08utTxZDgszPH8Iyk0yPin4ozvauA8zLHAJQ3uqRe2d2iNUWZieOAkcAc0mz035DpSqiYd3EMaaZ3ALdKyjLvoiOSP7AX6VJtJFA/lPEFIMuZdgMjJL0jIh4FkLQJ6R5ELp8Gvkrq2xVpFMWnMrYPLPtwf4YVk82nM4axMCKWSlqiVNztafLe7CUiviTpu5LOIHW5fDcifpEzBih3dEmPODYjTfzr2RWXe8jpccA2wB0RsYukd5F+b3L5KSlPnV48P5h0wjbg9yo7IvkXZxHnS/p4RPyy7HgK/wzcWMy0hVRa+ahcjUfEn4Hc/aeNXAA8QPoDPYU02id3OYFZxdn2WaQhji+SKeEpFbaruZmUWO4EFkmamGvSX53SRpf0cC7wFeA/SX+IPkXjImsDbVFELJKEpDcVJR8GdHZxD5v36Iq9QdLcHA13VJ8/tMclbV0sbyLVLQF4IMewtja64QyApLsjFXS7p0g6Q4Brc02fbxDPGGCtiLgnU3sX9PFyRMShOeKokXRnRGwn6Q7SfakFwH0RsVnmOGZHxHhJ99Ymukm6JSJ2zBzH5aQ/PF8gdfX8GRgSER/K1P55wJkRcUfxfDvgsIg4ZqDb7ogz/5p2uaStM57XFlMZKynHCJPvFF8b3nAe4LYbWVx8/Usx4uaPpJ9JVj1nk0qakOOmXkT8o1IBs89FxA8Gur1V0Gh0Se77H5CufFYDHpJ0LPB/wFtzBxERHyseTlaqs7M28N8ZQ9gOOFRSbX2LUaTie/em8AauLHtHnfnXnV3Wvg4HLouIPUuI5QJgU9JNpGUzGHMNZZN0c48bzg23ZYjjCOCXpEVDzgWGk6pantnnG1sbw7eAA+kxmzTnVZCkGyNi51ztrYrco0t6tL0NqftvHVLZ77WB02pnwJliWA24JyK2ytVmgxhG9/V6RPx+oNruqDN/Spww0UAXsGWU99e17BvOwLK67QA3kfkma52PUv5s0lslfZ803+Gl2saM3U9/38drRETWfv+ImFk8fJESBiIUMSyVNFfSqChhZbkiht8Dpax012nJv10uaQHuI3W7PFVS+6XecK4pzi4/zoprCee8D9MOs0lr8z/q55wEr5VWHmgf6eO1IPNNX0ldwMmsWNgt9+pzGwDzlCq/1v9RznJVqF5WuiPdtxzYtjus2+dNtbO72iUt6W5+9l/6ov9wHOmeQ/0MxpxdDdlvODeI4b9J9ZV6LlP33V7f1PoYfkka51/2bFIrSHoQ+FdWLLM9YN0cvcSxU6Pttfk6GdqfS7rRvNxKdxExaaDb7rQz/99QnFkVie4VSXeRb4m8epNLaHOZBpf5m0p6nrS4y9MZQxkZEXtnbK+R6cW/elnPeiQ1nG8SEf+Rqf1PRsTPJB3fSxy5S30/U8Iw1xXUJ3lJ6wMLMnfVlrbSXUck/3aa4VuT68yhD58B3k9aH1ak8gZ3AH8naUpE9DUEsZVul7R11K0bW4J1IuL79RskHZc5hvp6RsNIazvnLLL35uJr7oqqvfmK0nKSPa/GsnQ/KVX8PRV4jnTD+QLSSnOrSTo0InKN+PlLMTDlFuBCSU8DWVYe7Ihun6JOyOGkm6wzeS35vwCcl/NmlnqvY591Dd1ivP8REfGn4vnbgB8BRwA35xrhIOl+4J2k0hKv8NrPIVvfrhrXfLo7It6bK4YGMQ0DrmiDq6JSSPoZqUtyHq91+0Sumd+SZpFm/69NKoK4T0TcUczwvSjXZ0OpxlNtpbtPkk5YL4wMa010RPKvabMZvqWqnzxTPBepy2ernImvt6FsOfp2JR1MquX/QdKZVc2awKsRsftAx9AbSWsDs0qYXNUO5TZW+HzmJmlORIwrHs+PiC3qXhvw349eThJrJ62LgEdIKxLOGKgYOqXb5yOk8bq/LJ6fQhph8nvguIjIXtCsDdwi6SrgkuL5x4GbldbU/UuuIHobypbJ7aTRVuuTRlTUvADkGmI5ONKKcnfz2i/7INIokyz9/T20Q7kNgDskbRkRZZW2rl/bemGP1wb8jDiKxY4aKSYFbkVa9nPArtA74sxf0j3A9hHxstLC6d8jzWh9L3BAROxVaoAlKM70P04qpSzSAua/zD3voLehbBEx4EPZesQxGtgsIq6TtDowOCIGfCWtWpeTpE3rNi8B/ljS6Ku2KLchaT5pEmQp3YFKS2i+VLS7Oml9AYrnwyJiSI44+iLpqIj48UAdvyPO/Ekfmtp/3t8D50TEbGC2pAGvkdGOiiR/afGvTF8jlcldbihbzgAkHQlMIq3QtCmp+uuZwG45mgeIiEcytLUq2qLcBlDqvY6IGFRm+6tiIBM/dE7yV3HH/GXSL/T/q3std1dDWyiGen6LVC9FZL7hXKe0oWx1PgdsS6qmSUQ8VHRD5TCit+GVRSy5h1hOVVq85N9Jw1+HU7eaVQ5FWYVfl1lWwTon+f8XqYbOX0ldCrMAimGfZc2wLdtpwEciooz+3Hq1oWw3k3koW51XIuJvqScs9cOTb5z/IFKCLaNc8QraodxGO5RVsA7p84dlVRvfCsyNiKXFtg1I5Vkr9wGTdFtE7FBi++8E3kb6o7yQtJbyIaQ+/18X3XK5YjmNdJP7UOCfSCsn3R8RJ2doO+syoivTJuU2kHQ9aRGVUsoqWAclf1teUUTs7cAVlDOJ5irgSz0LlxU1Xb4SEX3Vmml1LKuRhjfuSToDvxY4O8fN77LnE/TUDuU2ijhKLatgTv4dS9K5DTbnnERzX299umWP8c5J0ro5Juysqr7+X3LrMQJrDWBQjhFYlnRKn7/1EBGllMmt09eN9tVzBCDpFxHxCRULY/R8PcewwnZK/IV2KLfRaATWRuQbgWV0SPKXtG5fr7fhL+CAkfRvEXGapNNpnPByVbKcKenIiDirR3yfIXU55PCCpB1I5YwrfYkr6T7SxKbBwKeUSn2XUm6jUOYILKNDkj8pmQTpgzyKtA6nSKsE/YHyFnQpQ210z6xSo0hrol4u6RBeS/ZdwFDgY72+q7XuIS1ruQFwMalmy5xMbbebjUglxttFmSOwjA5J/hGxCVBbw3d6RFxdPN8HKK1+S0n+ABAR5/d8QdJncwVRFJT7QDGpq9bH/OuIuD5jDN8Hvl/0LR8EnFvUtrkImBYRv8sVSxt4LEc9pdfhJqUy16tL2oM0AuvKkmOqlI664StpdkSM77FtVkR0lRVTbsXl/AE9h1JK+ipp3H/bDDssQzH34yfAe94IszxbRVI3qexJQ7knm/UYgQWpxERZq+5V0mplB9Biz0r6sqQxkkZLOplyC0ppAAAF50lEQVS0jm+VHABcIun9kKY+F1dEO5Jq+leOpCGSPiLpQuAa4Hekse5VUptstmYv/7KQtJ+kz0XE0uJ+0GhSd+CXJO2fKw7rvDP/dYGvkNZFDdKs0ilVuuELIOk9wOWkm2pHFpsPjoi/lRdVfkV3wsGkhVN+S1o8/YqIeKnPN3agdplsJuk24KCIeKJ4Poe0jOFw4NyI8GifTDqiz7+mSPLHSRoeES+WHU8Zij+A3cBhpAle1wHHAsMlVWrkE2mxjp8DJ1Ts+26kLcpLAENrib9wa/F/81xRbtwy6bQz/w8AZwPDI2KUpLHAURFRmcqekh7jtVETtV/42kioiIhS6rlYudplspmkhyPinb289khEbNroNWu9jjrzB/6TtEjFdICImCtpQrkh5VUb+WRWrx0Sf+HOXuZ/HEXqmrNMOi35ExFP1MYOF17tbV8zy+6fgSsk/QNwV7FtPPAm4KOlRVVBnZb8nyi6fkLSUODzlLNEnZk1EBFPk+Z/7EpaRxgyz/+wpNP6/NcHvk+a2CXgf4DPt9Elr5lZW+i05L9DRNy2sm2dzHWOzGxVdFryX2Esc7uMb86lbrRPwzpHviFsZtAhff7FbNYPsOJ6qWuRZjZWhuscmdmq6JTyDkNJMwQHs/yU9b8CVZ0yvk0t8QNExDVAw9WTzKx6Oq3bZ3SbVS4sjaRrgVuAn5G6gT4JTIiIvUoNzMzaQkckf0n/FRFfkHQljRcwqdyi0K5zZGZ96ZTkPz4iZntR6BVVuc6RmfWuI5K/rch1jsysL51ywxdIY/ol/a+k30l6VNJjxeImVVSrc7QAUp0jUheQmVlnDPWscw6pdshsXNPHdY7MrFedlvyfL4Y0muscmVkfOqrPX9KppEldlwGv1LZHxF29vqlDuc6RmfWl05L/DQ02R0Tsmj2YkrnOkZn1paOSv73GdY7MrC8d0effo54PpElNz5LWB32shJBK4zpHZrYqOmWo55o9/q0FdAHXSDqozMBK4DpHZrZSHd3tU5Q4uK6KXR2uc2RmfemIbp/eRMRz6jHQvdPV6hwBP5TkOkdm1lBHJ/9indA/lx1HZhcUX79TahRm1tY6ottH0r2sWM1zXeBJ4NCIeCB/VGZm7atTkv/oHpsCWBARL5URTzuQtAMwGRhNusITac7DO8qMy8zaQ0ckf1uRpAdoUOcoIhaUFpSZtY2O7vOvONc5MrNe+cy/Q7nOkZn1xcm/Q7nOkZn1xcnfzKyC3OffYVznyMxWRafU9rHXuM6Rma2Uu30qosp1jsxsRT7zr4hiBa9K1Tkys945+VdERescmVkvfMO3w6yszlH+iMysHbnPv8O4zpGZrQonfzOzCnKfv5lZBTn5m5lVkJO/WYtI+oKkNcqOw2xVuM/frEUkPQ50RcSzDV4bFBGvrvgus3L4zN8qRdKhku6RNFfSBZJGS5pRbJshaVSx33mS9q9734vF150l3SjpUkkPSLpQyeeBDYEbahVVJb0oaYqkO4EvS7q87nh7SLos6zdvVsfj/K0yJL0bOBnYISKeLUpenA/8NCLOl/Rp4AfAR1dyqPcC7ybNnbitON4PiqJ6u9Sd+b8ZuC8iTpEkYL6kERHxDPAp4NyWf5Nmq8hn/lYluwKX1pJzUfLi/cDPi9cvAD64Csf5bUR0R8RSYA4wppf9XgV+WbQVxfE/KWmdol2vtGal8Zm/VYlYcfZzT7XXl1CcHBVn7UPr9nml7vGr9P57tKhHP/+5wJXAIuCSiFiyinGbtZzP/K1KZgCfkLQeLKt0ejtQK3V9CHBr8fhxYHzxeD9gyCoc/wVSGe2GIuJJUlfRl4HzXl/oZq3lM3+rjIiYJ+kbwE2SXgXuBj4P/ETSvwK1vniAs4BfSfot6Y/GqpTHmEpaN+GpiNill30uBEZExP3NfC9mzfJQT7OMJP0QuDsizik7Fqs2J3+zTCTNJl1B7BERr6xsf7OB5ORvZlZBvuFrZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV9P8BdBaVedOfBNQAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "aggregations = {'target':['mean', 'count']}\n",
     "\n",
@@ -104,9 +311,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 648 different cities in our dataset\n"
+     ]
+    }
+   ],
    "source": [
     "cities = train['city']\n",
     "print(\"There are {} different cities in our dataset\".format(len(cities.unique())))"
@@ -114,9 +329,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1cbaaf457f0>"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX8AAAFTCAYAAADRKgwqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3Xu4VVW5x/HvT1DRRC2hUgEhs9JEULdomaamZWZ4NElNM0xDMy9dj3YzsjyaWZ0yjx4tL5mJSlpompZ38xIbxQugRzTNHeU9M5WUeM8fYy5YbBag7LXGXKz5+zzPflhzrrnXeNl7r3fNOeYY41VEYGZm1bJS2QGYmVl+Tv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFdS/7ACWZNCgQTF8+PCywzAzW6FMmzbtqYgYvKzj2jb5Dx8+nO7u7rLDMDNboUh69NUc524fM7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOroKYkf0m7SnpA0mxJxzZ4fpik6yXdJekeSbs1o10zM1s+fR7nL6kfcBqwC9ADTJU0JSJm1h32NeDiiDhd0ibAlcDwvrZtZvZqXXvdhn36/vft9FCTImkPzTjzHwPMjoiHI+JlYBKwR69jAlizeLwWMKcJ7ZqZ2XJqxgzf9YHH6rZ7gK17HTMRuEbSkcDrgJ2b0G57mLhWE17jub6/hpnZa9CMM3812Be9tvcDzo2IIcBuwPmSFmtb0gRJ3ZK6n3zyySaEZmZmjTQj+fcAQ+u2h7B4t87BwMUAEXEbMAAY1PuFIuLMiOiKiK7Bg5e5LpGZmS2nZiT/qcBGkkZIWgXYF5jS65g/A+8DkLQxKfn71N7MrCR9Tv4RMQ84ArgamEUa1TND0vGSxhaHfQH4lKS7gQuB8RHRu2vIzMwyacqSzhFxJWn4Zv2+4+oezwS2bUZbZmbWd57ha2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFNSf6SdpX0gKTZko5dwjEflTRT0gxJv2hGu2Zmtnz69/UFJPUDTgN2AXqAqZKmRMTMumM2Ar4MbBsRz0p6Y1/bNTOz5deMM/8xwOyIeDgiXgYmAXv0OuZTwGkR8SxARDzRhHbNzGw5NSP5rw88VrfdU+yr9zbgbZL+IOl2Sbs2oV0zM1tOfe72AdRgXzRoZyNgB2AIcLOkTSPi74u8kDQBmAAwbNiwJoRmZmaNNOPMvwcYWrc9BJjT4JhfR8QrEfEn4AHSh8EiIuLMiOiKiK7Bgwc3ITQzM2ukGcl/KrCRpBGSVgH2Bab0OuZXwI4AkgaRuoEebkLbZma2HPqc/CNiHnAEcDUwC7g4ImZIOl7S2OKwq4GnJc0Erge+FBFP97VtMzNbPs3o8ycirgSu7LXvuLrHAXy++DIzs5J5hq+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFOfmbmVWQk7+ZWQU5+ZuZVZCTv5lZBTn5m5lVkJO/mVkFNSX5S9pV0gOSZks6dinH7S0pJHU1o10zM1s+/fv6ApL6AacBuwA9wFRJUyJiZq/jBgJHAXf0tU1b3MjzRvb5Ne79xL1NiMTMVgTNOPMfA8yOiIcj4mVgErBHg+O+BZwMzG1Cm2Zm1gfNSP7rA4/VbfcU+xaQtDkwNCKuaEJ7ZmbWR81I/mqwLxY8Ka0E/AD4wjJfSJogqVtS95NPPtmE0MzMrJFmJP8eYGjd9hBgTt32QGBT4AZJjwDbAFMa3fSNiDMjoisiugYPHtyE0MzMrJE+3/AFpgIbSRoB/AXYF/hY7cmIeA4YVNuWdAPwxYjobkLb1kZmvWPjPr/GxvfPakIkZrYsfT7zj4h5wBHA1cAs4OKImCHpeElj+/r6ZmbWfM048ycirgSu7LXvuCUcu0Mz2jQzs+XXlORvZu2p59ib+/T9Q07arkmRWLvx8g5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhW0Qq/qOfzY3/T5NR456UNNiMTMbMXiM38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczq6CmJH9Ju0p6QNJsScc2eP7zkmZKukfStZI2aEa7Zma2fPqc/CX1A04DPghsAuwnaZNeh90FdEXEZsBk4OS+tmtmZsuvGWf+Y4DZEfFwRLwMTAL2qD8gIq6PiBeLzduBIU1o18zMllMzkv/6wGN12z3FviU5GLiqCe2amdlyakYZRzXYFw0PlA4AuoD3LuH5CcAEgGHDhjUhNDMza6QZZ/49wNC67SHAnN4HSdoZ+CowNiL+1eiFIuLMiOiKiK7Bgwc3ITQzM2ukGcl/KrCRpBGSVgH2BabUHyBpc+B/SYn/iSa0aWZmfdDn5B8R84AjgKuBWcDFETFD0vGSxhaHfRdYA7hE0nRJU5bwcmZmlkEz+vyJiCuBK3vtO67u8c7NaMfMzJrDM3zNzCrIyd/MrIKc/M3MKsjJ38ysgpz8zcwqyMnfzKyCnPzNzCrIyd/MrIKc/M3MKsjJ38ysgpqyvIOZLep7++ze59f4wkVXNCESs8Z85m9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXk5G9mVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhXUlOQvaVdJD0iaLenYBs+vKumi4vk7JA1vRrtmZrZ8+pz8JfUDTgM+CGwC7Cdpk16HHQw8GxFvBX4AfKev7ZqZ2fJrxpn/GGB2RDwcES8Dk4A9eh2zB3Be8Xgy8D5JakLbZma2HJqR/NcHHqvb7in2NTwmIuYBzwHrNKFtMzNbDoqIvr2ANA74QEQcUmx/HBgTEUfWHTOjOKan2H6oOObpXq81AZgAMGzYsC0fffTRPsVm1XTaYdf16fs/c8ZOTYrEACZOnNgWr9EO3nz99D6/xt92HL3U5yVNi4iuZb1OM878e4ChddtDgDlLOkZSf2At4JneLxQRZ0ZEV0R0DR48uAmhmZlZI81I/lOBjSSNkLQKsC8wpdcxU4BPFI/3Bq6Lvl5ymJnZcuvf1xeIiHmSjgCuBvoBZ0fEDEnHA90RMQX4KXC+pNmkM/59+9qumZktvz4nf4CIuBK4ste+4+oezwXGNaMtMzPrO8/wNTOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOrICd/M7MKcvI3M6sgJ38zswpy8jczqyAnfzOzCnLyNzOroP5lB/BavPLKK/T09DB37tyyQ1mhDRgwgCFDhrDyyiuXHYqZlWSFSv49PT0MHDiQ4cOHI6nscFZIEcHTTz9NT08PI0aMKDscMyvJCtXtM3fuXNZZZx0n/j6QxDrrrOOrJ7OKW6GSP+DE3wT+GZpZn5K/pDdI+p2kB4t/X9/gmNGSbpM0Q9I9kvbpS5vtZuLEiZxyyimv+fuOO+44fv/73y/1mHPPPZc5c+Ys2D7kkEOYOXPma27LzKy3vvb5HwtcGxEnSTq22D6m1zEvAgdGxIOS1gOmSbo6Iv7ex7YZfuxv+voSi3jkpA819fWW5vjjj1/mMeeeey6bbrop6623HgA/+clPWh2WmVVEX7t99gDOKx6fB/xH7wMi4v8i4sHi8RzgCWBwH9st1QknnMDb3/52dt55Zx544AEAHnroIXbddVe23HJLtttuO+6//36ee+45hg8fzvz58wF48cUXGTp0KK+88grjx49n8uTJQPog2Gqrrdh0002ZMGECEcHkyZPp7u5m//33Z/To0bz00kvssMMOdHd3A3DhhRcycuRINt10U445ZuHn7RprrMFXv/pVRo0axTbbbMPjjz+e+adjZiuCvib/N0XEXwGKf9+4tIMljQFWAR7qY7ulmTZtGpMmTeKuu+7i0ksvZerUqQBMmDCBU089lWnTpnHKKadw+OGHs9ZaazFq1ChuvPFGAC6//HI+8IEPLDbE8ogjjmDq1Kncd999vPTSS1xxxRXsvffedHV1ccEFFzB9+nRWW221BcfPmTOHY445huuuu47p06czdepUfvWrXwHwwgsvsM0223D33Xez/fbbc9ZZZ2X6yZjZimSZyV/S7yXd1+Brj9fSkKR1gfOBgyJi/hKOmSCpW1L3k08++VpePpubb76ZPffck9VXX50111yTsWPHMnfuXG699VbGjRvH6NGjOfTQQ/nrX/8KwD777MNFF10EwKRJk9hnn8VveVx//fVsvfXWjBw5kuuuu44ZM2YsNYapU6eyww47MHjwYPr378/+++/PTTfdBMAqq6zC7rvvDsCWW27JI4880sT/vZl1imX2+UfEzkt6TtLjktaNiL8Wyf2JJRy3JvAb4GsRcftS2joTOBOgq6srlhVbWXqPlpk/fz5rr70206dPX+zYsWPH8uUvf5lnnnmGadOmsdNOOy3y/Ny5czn88MPp7u5m6NChTJw4cZnDMCOW/KNZeeWVF8TXr18/5s2b92r/W2ZWIX294TsF+ARwUvHvr3sfIGkV4DLgZxFxSR/bK93222/P+PHjOfbYY5k3bx6XX345hx56KCNGjOCSSy5h3LhxRAT33HMPo0aNYo011mDMmDEcffTR7L777vTr12+R16sl+kGDBvHPf/6TyZMns/feewMwcOBAnn/++cVi2HrrrTn66KN56qmneP3rX8+FF17IkUce2fr//AriM2fstOyDzCqur8n/JOBiSQcDfwbGAUjqAg6LiEOAjwLbA+tIGl983/iIWPw0eQWwxRZbsM8++zB69Gg22GADtttuOwAuuOACPv3pT/Ptb3+bV155hX333ZdRo0YBqetn3Lhx3HDDDYu93tprr82nPvUpRo4cyfDhw9lqq60WPDd+/HgOO+wwVlttNW677bYF+9ddd11OPPFEdtxxRyKC3XbbjT32eE29cGZWcVpaF0KZurq6ojaypWbWrFlsvPHGJUXUWfyzNMvvzdf3/Zz3bzuOXurzkqZFRNeyXmeFWtvHzGxFtqzEndMKt7yDmZn1nZO/mVkFrXDJv13vUaxI/DM0sxUq+Q8YMICnn37ayasPauv5DxgwoOxQzKxEK9QN3yFDhtDT00O7zv5dUdQqeZlZda1QyX/llVd29SkzsyZYobp9zMysOZz8zcwqyMnfzKyC2nZ5B0lPAo/28WUGAU81IZy+aoc42iEGaI842iEGaI842iEGaI842iEG6HscG0TEMgtmtW3ybwZJ3a9mjYsqxNEOMbRLHO0QQ7vE0Q4xtEsc7RBDzjjc7WNmVkFO/mZmFdTpyf/MsgMotEMc7RADtEcc7RADtEcc7RADtEcc7RADZIqjo/v8zcyssU4/8zczswac/M3MKqijkr+knSSt3gZxLFauR9IHy4jF2oeSAyQdV2wPkzQmcwyvk7RS8fhtksZKWjlnDEsjadWyY8hN0u6130lOHZX8gfHAdEm3STpZ0oclvb6EOM6WtEltQ9I44PicAUhaS9IPJHUXX9+TtFbOGIo4Vpf0dUlnFdsbSdo9dxxt4n+AdwH7FdvPA6dljuEmYICk9YFrgYOAczPHAICks3ttrwFcWUIcYyWdUnx9OHf7wL7Ag0XOylZYu6OSf0QcGBFvAz4C9JDeWGWs//xR4OfFmdUngc8C788cw9nAP4pYPlo8PidzDBRt/ouU9CD9Xr6dO4jid3GWpGskXVf7yhzG1hHxGWAuQEQ8C6ySOQZFxIvAXsCpEbEnsMkyvqdV/iLpdIDiJO0a4Oc5A5B0InA0MLP4OqrYl01EHABsDjwEnFOcvE6QNLCV7XbUaB9JBwDbASNJ06NvAW6OiNtKiOUdwKXAX4A9ijdczvanR8ToZe3LEEd3RHRJuisiNi/23R0RozLHcTdwBjAN+Hdtf0RMyxjDHcC7gakRsYWkwcA1tZ9LphjuAg4HfgAcHBEzJN0bESNzxdArnu8AawFbAidFxC8zt38PMDoi5hfb/YC7ImKznHEUbQ8CDiCdLM4C3gr8KCJObUV7K9R6/q/Cf5M+Pc8Aro+IR3I2Xryx6j9N1y7+vUUSEbFFxnBekvSeiLiliG1b4KWM7de8LGk1ip+LpA1JVwK5zYuI00tot96PgMuAN0o6Adgb+FrmGD4LfBm4rEj8bwGuzxmApL3qNv8IfL34NyTtFRGX5oyH9D59pnhcRtfoWFL324bA+cCYiHiiuH85C2hJ8u+oM38ASe8EtgfeA2wEPBARH8/U9oZLez4iHsoRRxHLaOA8Fv4xPwuMj4i7c8VQxLELKcFtQrqs37aI44bMcUwEniAl3wUfPhHxzJK+p0VxvAN4HyDg2oiYlbP9ujheFxEvlNT20rofIyI+mTGW/YCTSB+AIuWOL0fEpIwx/Az4SUTc1OC590XEtS1pt5OSv6Q1ScnlvaTun0HA7RHxiYwx9APuzN2tsSTFz4SI+EeJMawDbEN6c90eEdlXTpT0pwa7IyLekjGGDYGeiPiXpB2AzYCfRcTfM8bwLuCnwBoRMUzSKODQiDg8VwztRtK6wFakv887IuJvmdv/TkQcs6x9TW+3w5L/PaR+/luAmyKip6Q4LgS+GBF/KaP9Iob/Ak6uJZbihtoXIiJLN4OkpXZxRcSdOeJoJ5KmA13AcOC3wOXA2yNit4wx3EHqbppSdw/mvojYNFcMdbEMIXVpbEvqFrwFODrn+3YJf6fPAY9GxLxMMdzZu0tY0j2tvu/QUX3+tR9WmZe0hUHALEm3AQviiIi9lvwtTffBiPhKXdvPStqNfH3M31vKcwHslCkOAIqx7J8mXdYD3AD8b0S8kjGM+RExr+jz/mFEnFrcJ8oqIh6TVL/r30s6tsXOAX4BjCu2Dyj27ZIxhv8BtgDuIZ35b1o8XkfSYRFxTasalvRp0s33DYsT15qBwB9a1W5NRyX/+ktaoMxL2pMyt9dIP0mrRsS/AIqbrtkm0ETEjrnaepVOB1YmvdkBPl7sOyRjDK8UfcwHArXx5LknWD0m6d2km6urAEeRbiqWYXBE1Pf/nyvps5ljeIRi1BNAMT/nS8C3SKP1Wpb8SR98VwEnAsfW7X8+x72ojkr+pNE+HwCmAETE3ZK2X/q3NF9EXFsM26oVZOguoZ/758C1xc21AD5JugGcnaRNSTd8B9T2RcTPMoexVa/7MNcVwz9zOgg4DDghIv4kaQSZx7UX7f8QWJ805+Ia4DOZY6h5qhiefWGxvR/wdOYY3lFL/AARMVPS5hHxcK+ro1aIiHhE0mI/f0lvaPUHQKf1+d8REVu3wZjyj5DGUd9MupR8N/C5iLgscxy7AjsXMVwTEVfnbL+I4RvADqTkfyXwQeCWiNg7cxx3AuNqI66KIY6TMw+/pTjbflux+UDmbqe2ImkY8GPSBMAAbiX1+fe1fOtrieEi0jDP2uiefUjdth8n/Z1u1cK2r4iI3YvBCEF6n9a0fDBCpyX/ycD3SX9Q25AuabsiYt/McdwNvD8iHi+230RKvtk+hCS9DngpIuZLejvwduCq3MlG0r3AKNLEmVHFz+InEZF1Gr2k95H6kx8mvck2AA6KiGxj3IsRPueRuhoEDAU+0WiIXwvaPpVF56AsIiKOanUMvTU6u5U0IiIajcxqVQyrkfrd30P6ndxC6hqcC6weEf/MFUtunZb8B5EuaRec7ZLOJLJeSvaeMam0aNPdOWdRSppGGu76euB2oBt4MSL2zxVDEccfI2JMEc+OpPVs7ouId+aMo4hlVdKHoID7a/dDMrY/DfhYRDxQbL8NuDAitszQ9lKHO0dE9i5BSX8gDUz4R7G9MXBJGSOPyiDpA8DAiJjca//HgCcj4netbL+j+vyLfvWsyW0JrpF0JemGDqSFm3J3uSgiXpR0MGkNl5PLGFkCdEtaGziLtLTCP0mzObPoNZu03obFrOucs0lXriV+gIj4P2VaUbN3cm+DEXEA/wVcLulDpA/ln5H5/StpI9IN1973pHLM//gmC2/817uONBnRyX9ZJP1nkdwaXtqWcEn7RdLwtdql5HnA5KV+R/OpGP20P3BwsS/777tupNUZkn4LrBkR9yzte5qs9uZ6I+ney7Wk38mOpOGeOZN/t6SfkqbwQ/rdZFtbCNpqRBwR8Zviw+8a0vDG/4iIBzOHcQ7wDdI9uh1JN+Vbfqe3sHpELLbwZET8rei2bamOSP4sHKrWXWYQkv4HOLa4jL24+CpL6Wu4AEj6NXAR8OvIvNYSQEQcVMRxBbBJRPy12F6X/Mspf5o0suYoUoK5iYVDT3MpfURcg5O0NUn3Yo4srsZynqytVozOU3GjeaKkm0kfCK02QFL/3pPJig/E1VrdeKck/1UlDSij37KXR4Bpkr4REb9Y1sGtFBE3AjfWbT9MSjq5fZ80guJESX8kfRBcERFzM8cxvJb4C4+zcNRNFsU9hu8XX6Vpg0levU/Ssl799DK3uCf3oKQjSKvwvjFT25cCZ0k6otYFV5zx/4gMV6QdccNX0mWkKeK/JY0ZviYiSpm1qFQk4/uk4WKnA/Nrz+XoX5b03xHxWUmX07gLbGyrY2hEac2jnYBPAbtGxJqZ2/8xaaG/C0k/l32B2RFxZIa272XJI23+RVqJ9sTIsOheu4yIaxeStiL1HKxNmti1JvDdiLg9Q9v9SbUtDgFqw1uHkbrlvt7qkXkdkfxhwQJme5Le1KOAX5NGUrR8GF2DWA4ETiDduKkl/4gMqxVK2jIipkl6b6PniyuCrIrhdB8mXQFsQTrzb3nSbRDHXqQRUJDWfsoy70LSBkt5uj9pSYGJkWFd/3YZEVfE0uhD8TnSlcG3y4ipDMX7463F5uyIyLL0esck/3pKq0juTRq/+4aIGJqp3XeSzvbnkCZ1/XUZ39LKWBaM8y+2+wGrRv6iMhcBW5Ouyi4GbqjFZAtJ+mZE5OhnbhuSTiZ1OdWPihPpA+A9OeaCSPodafJf/QKIkyLiA61uu2yd0ue/QPHL24t0lvkGIGdloMmks6hWrgfyal1LOrurTVJZjXSW9+7McZxNGtte1uJhwIKz/u+Q+nNVfEXu7qclyZX4Jf2owe7nSEuQ/DpHDHW2jYht67bvlfSHiNi2WPYhh0FRt6R2pAUQc/X5l6ojavhKGijp48XY+lmktbm/DQyLiJwLRY1uk8QPMKB+dmLxePUS4jgBOLT4UC7TycDYiFgrItaMiIHtkvgzGwCMBh4svjYjnSQdLOm/M8eyhqStaxuSxpCGoAJkWU4ZmF8sM1GLYQOWMhO6k3TKmf+fSJOoTgd+W9Z6KblnjC7DC5K2iGLdfElbUk4Zx31JY6enSuomjau+JvL3Nz4eJVXNajNvBXaqDS9UKqB+DWkZ5Xszx3IIcLakNUhXYv8ADim6LHMVUf8qqcxq7V7Y9sCETG0vUAwU2YC6nNzq+5Ud0ecvafXcfdntrhjFMIl0/wFgXWCfyFiwvFc8KwG7s3AE1NmkNe2zlFGU9EPgzcCvWLSMY7ZJXkp1lCey8E1e63rKWU3sAVKN2OeK7bVI1aveoboFEXMqYlBkrGjWq/1BLKw0d1tkXoFXqYj9PsBMFg67jVaPzOuIM/92S/ySdiKVKywtroiYqlQvtn4tm1KuiCRtRjr73410D+YC0uzn60hdEDmsCbwIvL9uX5B3hu9Pgc+RxrWXdQ/kZGC6pBtgQc3a/yrOtn+fM5BiraWPkCqb9a/NPYiI4zO0/Y6IuF8LK3nVTpKGSRoWeSvN/QepolvetaY64cy/3SgVZN6GtDb5zcXXLRHxbOY43k3xxqrti8zr6BeLmf2dlPh+Wf8HLunSyFvdrFQqlhxvgzjWBcaQkv8fI2LOMr6lVXH8lnSzeZEPw4hYWhW4ZrV9ZkRMkNRo1ntERLZKc5KuIo04yrqCqJN/C0lajzTk9IvAehGR7UpL0vnAhsB0Fr2UzDrLV9JbitnFpVJ71Is9CehHutqo73rKWs+4jP7lJcRRSu3gdlG3zMX6pLlJ17Lo30VL36sd0e1To7RE7pdY/A87d73YA0iTiUYCT5FmU96cMwZSFbFNSrix2ttflJaoHc6iv5OWX9r30g71Ymtn/V11+7LWM67rX55B3QRE0jpDud0qaWRE5L7RvIgSr5Bry1xMo1hrKaeOOvNXKqJyBotfRuZeOfEp0pT9M4Dro4QFzSRdAhxV5kSzIo7SLu17xTE9IkYva1+nK274btYOI9MkzSSNPvoT6Yy3dgN8s4wxtMUVchk66swfmBcRp5cdREQMKmb7bg+coLRm+AMR8fGMYQwCZhaLqdVfSuZe22dIROyauc1G2qFeLEpr17+TRdeOz3kV9DCpaHzpyZ9U0rNspV8hlzUKrNOS/+WSDicVQqhPeFmGE9YU6wwNI/0yhwNrUbfAWyYTM7e3JG1xaU8qYP9j0rrttXqxB+UMQNIZpIl2OwI/Id0PylbYpvAiabRP1v7lRqKo1VvMqB2wjMNb5T7SEOAyr5BLGQXWad0+jWp/Zh1HXcRxD+mG4i2kBcSy3VRsN+1wab8kkj4bEdlmtUq6JyI2q/t3DeDSiHj/Mr+5eTE0KucYuUeBFbGMBb4HrAc8QTpZmhUZSnzWrXo7kDTcuLQr5LJGgXXUmX9EjCgjAGj7AAALMUlEQVQ7BoBaYlOJpfIkbUMa3bIxsApplMkLJSxp0A6X9kvyeVJxk1xqM6xfLEaCPQ1k/ZuNxcs5DiXNwi7Dt0hDon8fEZtL2pHUHZfDFOBNLD4Q472kNf1zul7Sd8k8Cqwjkr+knSLiOi2hXmvOWZxFPO1QKu/HpDf1JaR+zQNJ69lnFRGPFiuKvon2+3vLVa6v5gqlesbfBe4knXmelTmG2ozWcaREuz6pm7QMr0TE05JWkrRSRFxfjEbKYQ/gK9GrpKikF0hVvH6aKQ4oaRRYu70Zl9d7SbNFGy0Bm3sWJ7RBqbyi3dmS+kVaUfMcSbfmjkHSkaQ30+MsOrSw9G4fMi/gFRHfKh7+Uqms5IDaMgutJmkgqd7Fx0gVzC4D3hIRQ3K0vwR/L7q+bgIukPQE+RZ0G9478QNERLek4ZliqLW5Y872ajoi+UexHG4U9VrbQZRfKu9FSauQbu6dTLqh1fKi0A0cTZq6XkphDknP0zjJiwx1UosYtgIei4i/FdsHkpY1eFTSxEwDEp4g9Wt/jTTbPCTtmaHdpdmD1BX2OVIx+7WAXCOflnaDOdffxQER8XNJn2/0fES0tNxnRyT/em0wlA7gsWLiSBQJ+CgWFpnP5eOkJbuPIL25hpISTm6Pkcb5lyIiBpbVdp3/JdVWoLgCPAk4knSj8UzSqJ9W+wqpG/B04BdKRXZKVXc/bL6k3wBPZxxyOVXSpyJikW43SQeTr6Zw7WSslL/RThvt03AoXUQcnDmOUkvlFX3s50VEroIYS4vlp6TF5X7DojezSi1inpOkuyNiVPH4NODJiJhYbGedaCbpLaS+/n1J94C+AVwWEf+XMYZtSB+Az5Bu+p5PmpeyEnBgRPw2QwxvInV9vczCZN9FGhyxZ+0qrZN1WvIvfShdu5B0NfDhiHi55DgaVqiKiG/mjqUsku4jFfqZJ+l+YEJtLZ0y17eRNJL0QbBPRGyYsd1u0pXIWqQrnw9GxO1Kq9BeGBmXlS5GGNV+/jMi4rqMbTeqqraA1/Z5bUodSifpuKU8HXU3/HJ4BPiDpCnAguGmuc+4q5Tkl+JC4MZi2Y+XKIYXSnor5XaJ3Usq4PKVzE33j6LinaTjI+L2Ip77e90na7mIuB5otLJnDoeRJpldTFpSOut/vtOSf6OhdD/J2H6jMf2vAw4G1iFd4uYyp/haiZL6FAGKJXMXu7zMvdhemSLihGJG7bosWsVsJVLff9XUz3bvXV2uc7oilm1d0pDbfUijnC4iLXueZen3Tuv2WbW2YJVSoYgBwNwyFrEqhtYdTUr8FwPfi4gnMrTbP4oSfe1AqXxkzQDSTed5EfGfJYVkJZP0b9KJUm3EVa3okUjDX1cuK7ayFMts70eaeHhMRJzf6jY77cz/NmALWFBP91+S7qzty0HSG0i/wP2B84Atcn2SF/5I8f+VdGpElHpmGYuvqPoHLayXaiWS9HpgaKPx7q0UEf1yttfulKqJ7UdaXvwqMo026ojkL+nNpJmKq0nanIV9Z2uSRv/kiuO7wF6km1gjI3NlnloYdY+3LaH9RRQfhjUrkUZUvLmkcCpPqXzjWNJ7fzrwpKQbI6LhWHNrHUnfJNW1nkWqt/3lnFftHdHtUyxWNZ6UWLrrnnoeODfX8g6S5pOGM85j0b7L2mJmLV9XR9KdEbFF78dlKRbbq/0s5pFuRB8fEbeUFlSFqSjSLukQ0ln/N2qj48qOrWqKfPEwC+971N4nWRY/7Igz/2KxqvMkfSQiflliHCuV1XaddxSrigrYsHgMmVfTrJvVOqLY/gSpv/8RYGaOGKyh/ko1fD8KfLXsYCqu1IUoOyL517lC7VEysEwblx1Aofes1hPJP6vVFnc8cDXwh4iYWkz6erDkmCopinoGZemIbp8atUnJQGuvWa1mtrhOO/Nvl5KBBv3qhp2+D5hQ91yn/d2tMCQNIdV52JbUx3wLaemRyhYcqqp26KNupluLKetWvtqs1l/TRrNajXNIS42vRxohd3mxzyqm07p92rZkYBUVC3jVZrW+UOx7G7BGq6sUWWONutzcDVcOSRdHxEcl3Uvj0YEe7fMatHPJwKwkbUsq4r4B6fdc+4PKVs+4tmZLr33ZVo+0hp6SdADpygzS5KJSai0YRxf/7l5G45125j+s0f6I+HPuWMpWrB75ORa/+e03eoUV75EfA+8inW3eChxVxfdI1XVa8q9dPom0jswI4IGIeGepgZVA0h0RsfWyj7Sqk/TZiMhZyN7qKNUe/w7wRlLuyjIptKOSf2/FmhmHRsShZceSm6STgH6k+sX1RVTc126LkPTniGh41WytJ2k2qfZG1mp/ndbnv4iIuLOYaVpFtbP+rrp9AVRmKWV71fIuom+9PZ478UOHJf9ehZBXIq1u+WRJ4ZQqInYsOwZbYXTu5X8bK7p7ALqLmsq/YtGr9JauSdZRyZ9Fi5bMI9WNLW2tn7K1STF7awOSnqdxkq+tqW/5fbju8YtAfbnZIHXZtkxH9vkXhVSipCWV20K7FLM3s/bUUTN8JW0q6S5SXcwZkqZJKqU4dht4d0QcCDxb1NF9FzC05JjMrCDpZEmHNdj/OUnfaXX7HZX8SatFfj4iNoiIDYAvFPuqqHcx+1coeQlZM1vE7jTOTz8EPtTqxjutz/91EXF9bSMibpD0ujIDKlGjYvZnlRuSmdWJiJjfYOd8SS0fgdVpyf9hSV8HasWPDyCt81M5EfGt4uEvJV1BKoztBdXM2seLkjaKiEXqKUjaiIVX7i3Tad0+nwQGk+6SX1Y8PqjUiDKTtFVR07i2fSBwMfCtXvV0zaxcxwFXSRovaWTxdRBplOJxrW68I0f7VJmkO4GdI+KZooLWJBZW0No4IlxBy6xNFANSvgTUBqbcB5wSEfe2vO1OSP6Spizt+YgYmyuWsrmClpm9Gp3S5/8u4DHSMrV3UO3p6q6gZWbL1CnJ4M3ALqS1yT9G6jO7MCJmlBpVOWoVtJ7CFbTMbAk6otunnqRVSR8C3wWOj4hTSw4pO1fQMrNl6ZjkXyT9D5ES/3BSndKzI+IvZcZlZrY0koYApwLvAeYDtwBHR0RPS9vthOQv6TzS3fKrgEkRcV/JIZmZvSqSfgf8gkXnJ+0fEbu0tN0OSf7zgReKzUaFkFtaEcfMbHk1GoWXY2ReR9zwjYhOm6xmZtXxlKQDSIM1IHVdt7zWdkec+ZuZragkDQN+TBqyHsCtpD7/R1varpO/mVn1dES3j5nZikbSqSylhGZEHNXK9p38zczK0V33+JvAN3I27m4fM7OSSborIjbP2aZHyZiZlS/7WbiTv5lZBbnbx8ysBJKeZ+EZ/+rAi7WnyDA51cnfzKyC3O1jZlZBTv5mZhXk5G9mVkFO/mavgqTDJB1YPB4vab2yYzLrC9/wNXuNJN0AfDEiupd1rFm7cvI3a6A4y/8iaSjePcBDwD+BR4Bzgb+QaiR/FTgkIvYsvm8X4NMRsVf+qM1ePXf7mPUi6Z2kpL5TRIwCjq49FxGTSWuy7F8U27gS2FjS4OKQg4BzMods9po5+ZstbidgckQ8BRARzyzpwEiXzucDB0ham7Qm+1VZojTrA6/qabY48drWWjkHuByYC1wSEfNaEpVZE/nM32xx1wIflbQOgKQ39Hr+eWBgbSMi5gBzgK+R7geYtT2f+Zv1EhEzJJ0A3Cjp38BdpBu9NecCZ0h6CXhXRLwEXAAMjoiZueM1Wx4e7WPWBJJ+DNwVET8tOxazV8PJ36yPJE0DXgB2iYh/lR2P2avh5G9mVkG+4WtmVkFO/mZmFeTkb2ZWQU7+ZmYV5ORvZlZBTv5mZhX0/+L+cbglP+QiAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "aggregations = {'target':['mean', 'count']}\n",
     "\n",
@@ -143,9 +379,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average in US: 0.5350073082967423\n",
+      "Average outside US: 0.01873286818644981\n"
+     ]
+    }
+   ],
    "source": [
     "train_not_us = train[train['country'] != \"United States\"]\n",
     "train_us = train[train['country'] == \"United States\"]\n",
@@ -165,9 +410,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZEAAAFICAYAAACREMOwAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3Xe4XFXZ/vHvTUKVTgKhJAQRhUgnVAXpRSDYQEAElKIC0n0JgsgPRRELAlJfUBALiIoGDaIi1leQoAjSJCIl0oKKUpQiz++PZ43ZTE6Sc/a0c07uz3WdKzN7dvZas2dmP6tvRQRmZmZ1LNDrDJiZ2dDlIGJmZrU5iJiZWW0OImZmVpuDiJmZ1eYgYmZmtTmIWFdIGifpGUkjav7/D0u6pN35Ksf+uKQnJT3WieMPlKRTJX2l1/kw6w8HEfsvSQ9I+pekpyU9Jen/JL1fUsvfk4h4KCIWj4j/9CMfW0ua0fT/PxERB7eajz7SGgscB0yIiDHtPn4/0p/tvRpIOlDSL/vY/oCk7cvjVSR9qxQA/iHpDkkHdj2z87mRvc6ADTq7R8SPJS0FvAk4G9gUeE9vs9UxqwJ/jYgn+npR0siIeKnLebL+uQL4PfkZPg+sA3S9IDC/c03E+hQR/4iIKcA7gQMkrQ0gaWFJn5H0kKTHJV0oadHy2t2SdmscQ9LIUkrcUNJ4SSFpZHntPWX/pyXdL+l9ZfurgOuAlUrz1zOSVmpu4pE0SdKdpcb0U0lrVV57QNLxkm4vJdSrJC3S/B5LifZHlbQuq+TzIEkPAT/pZ3ofKuk9K+lSSStIuq68vx9LWqaP9Pt8r+XlhSR9ufz/OyVNrPy/lUoJfKakP0s6ck6fY3lP55e8PCPpV5LGSPq8pL9LukfSBv05tqRNJP26nINHJX1B0kKV16PUXO8rxz5PkuaUtzbYGLgsIp6NiJci4ncRcV0H07M+OIjYXEXEb4AZwJZl06eA1wLrA68BVgZOKa99Hdin8t93Ap6MiN/2cegngN2AJclazlmSNoyIZ4FdgEdK89fiEfFI9T9Kem1J62hgNDAVuLZ6QQP2AnYGVgPWBQ7s4739uCmt6j5vAtYCdupnem8HdijnZncyOHwYGEX+zma70M/jvU4CrgSWBqYAXyjvfQHgWrIEvjKwHXC0pJ2aj990Lk4ueXke+DXw2/L8m8Dn+nns/wDHlP+3eXn9sKa0diMv7uuVdOeWr1bdBJwnaW9J4zqYjs2Fg4j1xyPAsqVUeQhwTET8LSKeBj4B7F32+xowSdJi5fm+ZdtsIuL7EfGnSD8DfsisQDUv7wS+HxE/iogXgc8AiwJbVPY5JyIeiYi/kRfG9fv9btOppYT7r36md25EPB4RfwF+AdxcSsbPA9cAGzQnMA+/jIippQ/pCvKiDHmBHh0Rp0XECxFxP/C/zPoM+nJNRNwaEf8uefl3RHy5HPuqSt7meuxyjJtKqf8B4CIy2FadERFPRcRDwI0M/LwPxJ7kuf4I8GdJt0nauIPpWR/cJ2L9sTLwN7IUvhhwa6WVQsAIgIiYLuluYHdJ15Kl6T4vnpJ2AT5KltwXKMe9o5/5WQl4sPEkIl6W9HDJZ0N1pNVz5f8MxMMDTO/xyuN/9fF88QGm35z/RUpT4Kpk89dTlddHkBfTOelv3uZ67FIj+xwwkfy8RgK3ziPffb5vSc9Unk4oQafqJWDBPv7rgsCLABHxd2AyMFnSKDK4f0fSKuGVZbvGQcTmqpTsVgZ+CTxJXnReX0rcfWk0aS0A3BUR0/s45sLAt4D9ge9GxIuSvkMGJIB5XQAeITtRG8cTMBaYU57qqOahk+kN9GL3MPDniFijDWkP9NgXAL8D9omIpyUdDbyjTkIRMa+g+hAwTpIaAaHUcJenEtArx3tS0meAA4Blgb/WyZcNnJuzrE+SllR2kl8JfCUi7oiIl8nmjbMkLV/2W7mpPf5KYEfgA8yhKQtYCFgYmAm8VGolO1ZefxxYTjlCrC/fAHaVtJ2kBckhus8D/1fnvfZDJ9Ob13tt9hvgn5JOkLSopBGS1m5TM868jr0E8E/gGUlrkp9xp9wM/JusZSxSBiGcAUyjBBFJnyr5GylpiZKf6RHhANJFDiLW7FpJT5Ol0pPI5ovq8N4TgOnATZL+CfwYeF3jxYh4lOy43YJsb59N6Us5krw4/53sO5lSef0eskZzfxkJtFLT/78X2A84l6wd7U4OTX6h/tues06mN6/32sf+/ynprw/8ueTnEqC/QaiVYx9PflZPk4WJPj/fdih9SbsCW5MDO+4nmxX3qjRVLUb28TxVXl+VbEK1LpKbDs3MrC7XRMzMrDYHETMzq81BxMzManMQMTOz2hxEzMystmE32XDUqFExfvz4XmfDzGxIufXWW5+MiNED/X/DLoiMHz+eadOm9TobZmZDiqTZVgLoDzdnmZlZbQ4iZmZWm4OImZnV5iBiZma1OYiYmVltPQ0iknaWdK+k6ZIm9/H6geVez7eVv4N7kU8zM+tbz4b4ShoBnEfel3oGcIukKRFxV9OuV0XEEV3PoJmZzVMvayKbkDeQub/cl+FKYI8e5sfMzAaol5MNV+aV97GeAWzax35vl7QV8EfgmIh4uI99zKyNZkye2y3b522VM7ZsU05ssOtlTUR9bGu+Q9a1wPiIWJe8g97lfR5IOlTSNEnTZs6c2eZsmpnZnPQyiMwAxlaerwI8Ut0hIv5abpMJeTvOjfo6UERcHBETI2Li6NEDXvrFzMxq6mUQuQVYQ9JqkhYC9qZyn20ASStWnk4C7u5i/szMbB561icSES9JOgK4HhgBfDEi7pR0GjAtIqYAR0qaBLwE/A04sFf5bbtTl2rDMf7R+jHMzFrQ01V8I2IqMLVp2ymVxycCJ3Y7X2Zm1j+esW5mZrU5iJiZWW0OImZmVpuDiJmZ1eYgYmZmtTmImJlZbQ4iZmZWW0/niZiZDXY3/GT1lv7/dtv+qU05GZxcEzEzs9ocRMzMrDYHETMzq81BxMzManMQMTOz2hxEzMysNgcRMzOrzUHEzMxqcxAxM7PaHETMzKw2BxEzM6vNQcTMzGrraRCRtLOkeyVNlzR5Lvu9Q1JImtjN/JmZ2dz1LIhIGgGcB+wCTAD2kTShj/2WAI4Ebu5uDs3MbF56WRPZBJgeEfdHxAvAlcAefez3MeBM4N/dzJyZmc1bL4PIysDDleczyrb/krQBMDYivje3A0k6VNI0SdNmzpzZ/pyamVmfehlE1Me2+O+L0gLAWcBx8zpQRFwcERMjYuLo0aPbmEUzM5ubXgaRGcDYyvNVgEcqz5cA1gZ+KukBYDNgijvXzcwGj14GkVuANSStJmkhYG9gSuPFiPhHRIyKiPERMR64CZgUEdN6k10zM2vWsyASES8BRwDXA3cD34iIOyWdJmlSr/JlZmb9N7KXiUfEVGBq07ZT5rDv1t3Ik5mZ9Z9nrJuZWW0OImZmVpuDiJmZ1eYgYmZmtTmImJlZbQ4iZmZWm4OImZnV5iBiZma1OYiYmVltDiJmZlabg4iZmdXmIGJmZrU5iJiZWW0OImZmVpuDiJmZ1eYgYmZmtTmImJlZbQ4iZmZWm4OImZnV1tMgImlnSfdKmi5pch+vv1/SHZJuk/RLSRN6kU8zM+tbz4KIpBHAecAuwARgnz6CxNciYp2IWB84E/hcl7NpZmZz0cuayCbA9Ii4PyJeAK4E9qjuEBH/rDx9FRBdzJ+Zmc3DyB6mvTLwcOX5DGDT5p0kHQ4cCywEbNudrJmZWX/0siaiPrbNVtOIiPMiYnXgBODkPg8kHSppmqRpM2fObHM2zcxsTnoZRGYAYyvPVwEemcv+VwJv6euFiLg4IiZGxMTRo0e3MYtmZjY3vQwitwBrSFpN0kLA3sCU6g6S1qg83RW4r4v5MzOzeehZn0hEvCTpCOB6YATwxYi4U9JpwLSImAIcIWl74EXg78ABvcqvmZnNrpcd60TEVGBq07ZTKo+P6nqmzMys3zxj3czManMQMTOz2nranGVmNiennnrqoDiGzZ1rImZmVpuDiJmZ1eYgYmZmtTmImJlZbQ4iZmZWm4OImZnV5iBiZma1OYiYmVltDiJmZlabg4iZmdXmIGJmZrU5iJiZWW39CiKS3ibpPkn/kPRPSU9L+menM2dmZoNbf1fxPRPYPSLu7mRmzMxsaOlvc9bjDiBmZtasvzWRaZKuAr4DPN/YGBHf7kiuzMxsSOhvEFkSeA7YsbItAAcRM7P5WL+CSES8pxOJS9oZOBsYAVwSEWc0vX4scDDwEjATeG9EPNiJvJiZ2cD1d3TWKpKukfSEpMclfUvSKq0kLGkEcB6wCzAB2EfShKbdfgdMjIh1gW+SHfxmZjZI9Ldj/UvAFGAlYGXg2rKtFZsA0yPi/oh4AbgS2KO6Q0TcGBHPlac3AS0FLjMza6/+BpHREfGliHip/F0GjG4x7ZWBhyvPZ5Rtc3IQcF2LaZqZWRv1N4g8KWk/SSPK337AX1tMW31siz53zPQmAp+ew+uHSpomadrMmTNbzJaZmfVXf4PIe4G9gMeAR4F3lG2tmAGMrTxfBXikeSdJ2wMnAZMi4vnm1wEi4uKImBgRE0ePbrWCZGZm/dXf0VkPAZPanPYtwBqSVgP+AuwN7FvdQdIGwEXAzhHxRJvTNzOzFs01iEj6n4g4U9K59NHUFBFH1k04Il6SdARwPTnE94sRcaek04BpETGFbL5aHLhaEsBDEdHuYGZmZjXNqybSWOpkWicSj4ipwNSmbadUHm/fiXTNzKw95hpEIuLa8vC5iLi6+pqkPTuWKzMzGxL627F+Yj+3mZnZfGRefSK7AG8GVpZ0TuWlJcmlSMzMbD42rz6RR8j+kEnArZXtTwPHdCpTZmY2NMyrT+T3wO8lfS0iXuxSnszMbIjo71Lw4yV9klwocZHGxoh4dUdyZWZmQ8JAFmC8gOwH2Qb4MnBFpzJlZmZDQ3+DyKIRcQOgiHgwIk4Ftu1ctszMbCjob3PWvyUtANxXZpn/BVi+c9kyM7OhoL81kaOBxYAjgY2AdwMHdCpTZmY2NPR3AcZbysNngI7cKtfMzIaeeU02/HxEHC3pWvpegNGLIZqZzcfmVRNpjMD6TKczYmZmQ8+8Jhs2ZqkvC0yd002hzMxs/tTfjvVJwB8lXSFpV0n9HdVlZmbDWL+CSES8B3gNcDV598E/SbqkkxkzM7PBr981ioh4UdJ1ZAf7osAewMGdypiZmQ1+/aqJSNpZ0mXAdOAdwCXAih3Ml5mZDQH9rYkcCFwJvM+d62Zm1tDfPpG9gd8BWwJIWlTSEp3MmJmZDX79bc46BPgmcFHZtArwnVYTL81k90qaLmlyH69vJem3kl6S9I5W0zMzs/bqb3PW4cAmwM0AEXGfpJYWYJQ0AjgP2AGYAdwiaUpE3FXZ7SGyKe34VtKyOVvn8nVaPsYdB9zRhpyY2VDU3yDyfES8IAmAMk9ktmVQBmgTYHpE3F+OeSU54uu/QSQiHiivvdxiWmZm1gH9nWz4M0kfBhaVtAM5X+TaFtNeGXi48nxG2WZmZkNEf4PIZGAmcAfwPmAqcHKLaauPbbVqN5IOlTRN0rSZM2e2mC0zM+uv/i4F/7Kk7wDfiYh2XaVnAGMrz1cBHqlzoIi4GLgYYOLEia02s5mZWT/NtSaidKqkJ4F7gHslzZR0ShvSvgVYQ9JqkhYC9gamtOG4ZmbWJfNqzjoaeAOwcUQsFxHLApsCb5B0TCsJR8RLwBHA9cDdwDci4k5Jp0maBCBpY0kzgD2BiyTd2UqaZmbWXvNqztof2CEinmxsiIj7Je0H/BA4q5XEI2Iq2b9S3XZK5fEtZDOXmZkNQvMKIgtWA0hDRMyUtGCH8mTzmbvXXKvlY6x1z91tyImZDdS8mrNeqPmamZnNB+ZVE1lP0j/72C5gkQ7kx8zMhpB53R53RLcyYmZmQ09/JxuamZnNxkHEzMxq6/ftcc2s8z77zt1aPsZxV32vDTkx6x/XRMzMrDYHETMzq81BxMzManMQMTOz2hxEzMysNgcRMzOrzUHEzMxqcxAxM7PaHETMzKw2BxEzM6vNQcTMzGpzEDEzs9ocRMzMrLaeBhFJO0u6V9J0SZP7eH1hSVeV12+WNL77uTQzsznpWRCRNAI4D9gFmADsI2lC024HAX+PiNcAZwGf6m4uzcxsbnpZE9kEmB4R90fEC8CVwB5N++wBXF4efxPYTpK6mEczM5uLXgaRlYGHK89nlG197hMRLwH/AJbrSu7MzGyeFBG9SVjaE9gpIg4uz98NbBIRH6zsc2fZZ0Z5/qeyz1+bjnUocCjAuHHjNnrwwQfnmvb4yd9vOf8PnLFry8ewweW89/+kpf9/+IXbtiknZq805sbbWj7GY9usP9fXJd0aERMHetxe1kRmAGMrz1cBHpnTPpJGAksBf2s+UERcHBETI2Li6NGjO5RdMzNr1st7rN8CrCFpNeAvwN7Avk37TAEOAH4NvAP4SbSh6uRahJlZe/QsiETES5KOAK4HRgBfjIg7JZ0GTIuIKcClwBWSppM1kL17lV8zM5tdL2siRMRUYGrTtlMqj/8N7NntfJmZWf94xrqZmdXmIGJmZrU5iJiZWW0OImZmVpuDiJmZ1eYgYmZmtTmImJlZbQ4iZmZWm4OImZnV5iBiZma1OYiYmVltDiJmZlabg4iZmdXmIGJmZrU5iJiZWW0OImZmVpuDiJmZ1eYgYmZmtfX09rhmZjZvj22zfq+zMEeuiZiZWW09CSKSlpX0I0n3lX+XmcN+P5D0lKTvdTuPZmY2b72qiUwGboiINYAbyvO+fBp4d9dyZWZmA9KrILIHcHl5fDnwlr52iogbgKe7lSkzMxuYXgWRFSLiUYDy7/I9yoeZmbWgY6OzJP0YGNPHSyd1IK1DgUMBxo0b1+7Dm5nZHHQsiETE9nN6TdLjklaMiEclrQg80WJaFwMXA0ycODFaOZaZmfVfr5qzpgAHlMcHAN/tUT7MzKwFvQoiZwA7SLoP2KE8R9JESZc0dpL0C+BqYDtJMyTt1JPcmplZn3oyYz0i/gps18f2acDBledbdjNfZmY2MJ6xbmZmtTmImJlZbQ4iZmZWm4OImZnV5iBiZma1OYiYmVltDiJmZlabg4iZmdXmIGJmZrU5iJiZWW0OImZmVpuDiJmZ1eYgYmZmtTmImJlZbQ4iZmZWm4OImZnV5iBiZma1OYiYmVltDiJmZlZbT+6xLmlZ4CpgPPAAsFdE/L1pn/WBC4Algf8Ap0fEVd3Nqc1PDr9w215nwWzI6VVNZDJwQ0SsAdxQnjd7Dtg/Il4P7Ax8XtLSXcyjmZnNQ6+CyB7A5eXx5cBbmneIiD9GxH3l8SPAE8DoruXQzMzmqVdBZIWIeBSg/Lv83HaWtAmwEPCnLuTNzMz6qWN9IpJ+DIzp46WTBnicFYErgAMi4uU57HMocCjAuHHjBphTMzOrq2NBJCK2n9Nrkh6XtGJEPFqCxBNz2G9J4PvAyRFx01zSuhi4GGDixInRWs7NzKy/etWcNQU4oDw+APhu8w6SFgKuAb4cEVd3MW9mZtZPvQoiZwA7SLoP2KE8R9JESZeUffYCtgIOlHRb+Vu/N9k1M7O+KGJ4tf5MnDgxpk2b1utsmJkNKZJujYiJA/1/nrFuZma1DbuaiKSZwIMtHmYU8GQbstOqwZCPwZAHGBz5GAx5gMGRj8GQBxgc+RgMeYDW87FqRAx4Lt6wCyLtIGlanWrdcMzHYMjDYMnHYMjDYMnHYMjDYMnHYMhDL/Ph5iwzM6vNQcTMzGpzEOnbxb3OQDEY8jEY8gCDIx+DIQ8wOPIxGPIAgyMfgyEP0KN8uE/EzMxqc03EzMxqcxDpMkkjOnBMf46DjCT1Og9m3eCLTxdJ2grYvDxu27lvrG4saVJZ0HLQmV8uqpX3uURPMzIHjfxJWqSb6XVb5X3OF9+7uvo6PwO9NjmIdFAfH9AWlKXwI+LlVr/gkjaX9PZKWscBg/JHE6XzTdJ+kj4q6RhJr+5mHrpxQYmIkLQz8CVJH5Z0YCdqn3VIUsnf7sDXJS3eybQaDzuVxtzSjlmdvYv1IP3ZrquDMZhVz5OkPSTtLWntOd1yY04cRDqo8gG9VdIbIuIM4AFJ51Rfb8EY4AxJ7yjHWoRBGkQAJB0GHAH8DVgJuFrS6zqQTqMUOlHSxpI2gLac7/6kvQXwWeA0sta5PXlDtZ6rBLiPAWdHxDOS2n47iEqw2hr4tKTDJW3Z7nTmpPK7ex9wqaRTJO3XxfQbLQMbShonaZFyPgbVb7Nyno4APkzOeP9V+Y70m4NIB1QuYiMlLQh8Brhc0lnAecCzkjZr9fgRcQ3wAeAESbsBPwL+1ShhSlq2l1/cPtJeGzgqIs6NiA8BXwdOltTW0mL5wU4CLgB2Ac4s56cbxgOnAAuTQf6kiPiXpPFdSn9eNiAD3IOS9gKmStpX0hLt+q5UAshlwH3AOsA+kvZvx/H7Q9J7gH2A08nVwDfqQpqqPD6cvMXF/wMulLTEYAkkTflcmzxPjfs/zQDOb7Rw9IeDSAdUSryrRcSLwNuAL5JV608Am5Ef3IA1VUGPBcaSF4VPk6WJs4DvSfomcC6waAtvpbamfDaarZYHdq/s9gPgeeBfbUhvocrjUWSNZ3vgMfK839SJZqVKgWG5sukv5IXrUuDNEfFgCWAHd6sfoq/8VTwOHAJ8BVgF+A2wB7BQm2tq6wOnR8SFwEeAG4GNJS3VxjT+S9K6ktasbFoCOBjYGHgZ+FDZb3yH0l+o8n3fDlgV2BI4lax5XzIYAknT73Jv8oaAk4CdgLdFxOuBC8lWgm37c0wHkTaqXFAWkLQSeTE/DphAXig/R5ZS/wC8S9IyA/1CVb4Au5E/kB9GxLXA0cBtwK+BHYGDgBMj4rm2vLkBquTzA8BHy/s8CXh7OScA6wGrAy1dWCSNBi6QtF7Z9B+yRLUf8G7gwIh4Eti6nReRSrPN7uSPbiXgXuAnZIBcStKmZFC5KSL+3a60B5i/XSV9XNKZwJXACcDeEfE5MtitBizbalrl30Y/y4vkvYBGRcRM4KdkTXRUK+nMxaHAJyvNo/8Bfkm+zx0j4qXSvDWp3U14yvsc7S5pwVKA+Rr5Xh8iCxWfJb+P35C0eDeaVeek8rt8C1mYGBkRfyU//9vLbvcD3y7/9uug/mvDH2XiZnm8fPl3FPBB4EzgTrJ6u0J5bakW0loJ+B7w08q2BchS/gPAW3t9Pkqe3kEGtlUr29YB7gG+XL60r29TWueTzWOvL88/T5a61ynPty55WbPN73Fb4PfApuX5CGA74Ejg5vI57dH8HeniZ7ADcAt5UbuHrBE3Jhm/Bbijkb8W0mgcb5PyGawHLE0GzzPLBeo1ZAHnNW1+fyMqjz8FfANYA1ixvNezgQXJO6jeAUzowDnenKxlv7r8DtcD7gYOquwzFvgksHK3vwN95Hd94Abg4Mp3dmeydnolWTtdtd/H6/UbGm5/wDHkfeF/ChxP3sd+JeAi4AWy2WnEAI+5QB/btiFLWic2bX8z2YzWi/feuJgsUP49GTiyPF6w8b7J5qVlgNFtSLN6Efks8E3g9cCGZF/Uj8mmrTuB3Tvwng8sAWMiWfu7kaxxrVgupEtUz00XPoMVgM0qz08vedsV+BUwrvLa24Bt2pE/svZ7JfBHYFq5kG5GNq9OKwHk7W1+r6OA11XSX7gEja+Qtf9NyMLFD8n+wrXbnP7ClcdjyELiUeX5ROBPTYFkQL/7NuZTTc/XJ2ugNwJrlW2LAW8ADmOABS0ve9IiSQvErNEYe5HtsDuTQWMcsHM0PsmsTk+NiIf7eexGB3rj/+9fjvk0cBWwFvBe4PaI+HQ739dANbW1rhgRj5YRMduQncuPldfeCTwRETe2K83SRPBM2fYpsj36dLIpYS/gOeChiPhpNZ+tpFl5vjX5ma8F/C8Q5AXkMxFxb910auZtJNms80bggoj4haSTyQvq8sAHIuI+SfsAy0bEeW1Kd3XgGmC/iLi9DCAZD3y0PB8LvBARj7d6/pvSXReYDDxL1gjXjhzE8AWyT+T0iPijpEUBIqLlvrdK2kuTn/MdwFvJ2ugywDuB30TEeZI2IgsxR0XEl9uV9gDzWf1dbkL2gTwBLE4WfpYkvyt3106kF5FxuPwBrwMOrTyfRI4EOQG4HliwbN+o5vGXqzw+kOxLeTvwM7LDbmJJbyqlBNSj81Btyjua7BN4FVkbuBg4nLyw7UVWlce3K01y9NVFwImUpgJy8MLXaX/Js5HmrmQJ+wqyCePVjc8KeC15QVm/R5/Fa8tncBGwLhncngQOKa9vBtwFbN/GNJcj29BfU9k2Bbi18VnTxpoYOQig8fhjwDOUppnK9nPK72KNDp3nV5H9m78g+8HGlu07kTWhD5Tn69HmJrwB5rPxnT2CbF79BHAtGTxWJEePfamV89STNzYc/sgmqm3JKvWaZHXw7WSfxNWV/d5XLjaLDeSHRJbkvkhW0V8FXA7sVl5bnhxB8Yny/I30qK2VV1bpDwJuojSZkO3DO5QL/NRyYVm3jWnvSAbWjcn+lW8AW5TXPgt8B1i8ze9385LmTiWN7wFvKq/tVl6b1IPPoRrIVwX+B7iEHLiwBRnYriCblVpq1qtcmEaUz3hk+a6+i6zhQI6Muwm4rs3vc+ly7JWA95M1kUOA68jmucUq+36k3b+LpvO8MdnPdEH5vY4s23co3/WD25n2APO5UuXxW8im78XJfqP7yH6ypcm+mpMofbW10urVmxzKf+VH+jVgNDmE9kvAyeW1z5cf6qbAsdTszCtf0N9SSl1k/8LHmFXiXYXsd2nrRXKAeXwt2VnY6Os4vlxIty+P7yFLQMuQgbBteS0XrnPIkt4O5VydQ7ZLNzq5X9umz/qQyvOjgbMqzz9QAsergDdV0u5aJ3rlor5R+d6sShZaGoFktXIBWR54dSv545W1sSvIfqcNyHb268pF6hSy/2UdMrCv1Op7rKRfrQH8gVk1gHeRNeCdyKHu57b7M+CVAeRtZP/juHIOPkVpcSh53K6d73uA+RxNFm4OLc8nkEH3ELJvSGS/7e3kyMiW+mo8xLeGiHiQvDD8R33rAAAacUlEQVSeHtnO+lVgeUnHR8TR5Ae0F9mcsFdE3FUjjVvIAPT6sul2stazfRlGuCE5/r2XnVr/JEffbKhcs2s6GTSOBx4GPkrW1paIiGej9Fu0qrTtbhMRR5IjsE4A3lierwPsL2mZiPhjG5IbDUxWzuqFfI9LSBoDEBEXkJ/T2Ij4WUTcXLZ37XOJ+O9M9CvIuQnTySa2b5IDCk4DNoyIJyLi/lbyV9LahSzQXEB+J79FFqYOJjvWlyWD67JkLb3loc2V/sFnyZFFY8jS9UhJIyPiq2TA3IssxHyp3Z9B43iSPkQWEB+MiIfIwTILA3tKOpcMZr+JiEfamX5/lHk4z5Id5ztJ2i8i7ip5WYfsqwvg/8iO/2Ui4j+tpNn2JQ+Gq0on7oKREwiPIOc/rEGOchhBjhU/FjgzIl6o7NvfNLYnS3VPkyW4pclg8buImFLmQ2xF/lgXBj5YflRd1RhMEBGPlc7c/cj21YPIH/jLEfFseT9jyDkD7bQ6WeL+EbmkyCjgdZKeIi+a/xsRf29HQhExTdK+wHmSXiCHJr8H2FfSTeSIu43oUTBXrtM0hpxMN4msddxHDl54QtI3yHP0tzalN4Ks/b2LHLa7OnkRvQJ4f0RcWvbbluyXeVtEtJR2U+fwYmRNf2uyY/gwcpDJNLLwdj3wfLsKLH3kZW2yufKNkhYpAyuWIUdlvpc8N4dExNOdSH8eeduJrG18gez/+A85yXVkRFxWdttO0sZkrXnfyDk8relFdWso/lE6Spk1fHU02aTVGNI3giwBXUo2I4gBVqfJADGZ7KQ8lyzNX8Erh2UuRVahWx4eW/M8VKv0byabScaRJdOvA6uU1w4jm5jW6UAeNiUD92vL86PJDvs7gV079L43B34H7E0Grc+TQ1p/RgeGDtfI3+Ryzm+idJICe5Kd3gu24zOnDFQgRz6tUN77umXbT8jRcI05UisAq7f5Pb6/nPP/IZvPliCH9H6i/F5upoX5V/1If9Hy2d9KDh2+oORnJvC+ss9sw/G79PnvStYCJzWuDSW/k8iO9D3KNetkcjma9vVN9uIND7U/svPwZrKjdjJlIg450uU+XjnRbGtqdFI1B5zyBdiZHN10JG0Y0dTmc3IYOcpnfHneCCRfJdveN6K0v7eYTuMC9hrKQILy/BiyGWXxyuttn0jWlJdGINmv8nmPreazy5/BBLIWKLLg8XfKQIdy/m8F1mvT+d+5fN6Ndv9lyc70CeTAjs8ya6Jn2y+kJYD8nKyB/pSsdexE9j8cXIJI2y6MfaS/NdkXs0L53V8IbFBeezdwbLc//0reRpF9RNs3fxfJRVn3KNeufTvxXe3Jmx6KfyWQ7ElW3R8uX5wNyWat/duYTqOTuvHjfSNZcjiBUsrv9R/ZtnpL4wJa2b4qWUK/uJ1fVHIS1O5kzW8qsD/Z1zK5C4Fjgabnm5NNJ0f06Nw3vhebkX0AvyLn4ixKdjRfRA52uI0WZqI3XYjWKAHkDU37XEjWlB+mjBzs0HtulKCXIleA+EkJKt+n1DzbHbiav7/l+/ZFsr9vdGX7++jQTPgB5HUZcjRYYxBO83d2LLl6xNfLOXQQ6cGH1Pyh7E2OyPg+uT7OzVTGrtdMY8m5vLZN+cEu06P3r6Z/1we+VXm9MbRxYbJUtHyb0/808OHy+N0loN5JNiNc0IH3uRbZIdyo5Yxo2m8LchJZrfk/bcjn9uX9H1gubJeRw50XI/trDiYHGsx2Mezn8ceRgbpRoFkH+Ebl9eqw7qUp8yDadXHq6zhkIe51wA/K8xXIprtL5/bbaUNetqw83opswvoQOXBhPB2YCV/nfJGDDN5e2db4Ta5evi+L0KGRnD1740Ptj6Y+DnKyzmvIZoTfU+m3qHHsrYCjG+nMYZ9Fe/W+q++5kReyc/PoymvvIyfgtXwhaT4G2a57ftO2N5YLSFv7QMgmkkfJEvbPmdXG3xxILgS27sHnsQA5hLUxeXBMCRzXAbu0KY1XkwM8RpHNRcuQfU57V/bZBfhYh9/rIeTIslNKYBtP1rAWKt+Jy2hz3yCVpmiyz+UqKgUVskB3G9kPM65Xv8tKfhqB/ihypORGTa8fTg4GWaRjeejlCRisf8yhalzdzqxS6yK0WBIihwLfA2zX6/felK9qADmMLH2fTI4A2pTssLuMvKPiNNrYiU42GzWaKhYsF/Qjms79ws35bDHNCWRzXGPC4qfIwQGNjspG6W58uWj3ZCZyuWD8HBhVnq9IlojPo/TPtfqZl+/1T8iVEZYgl/O4hOz32qFcSNsdwKsTBY8s37etyKbTj5Ttl5IFmDvb+X0rx16THDb/OcqaV+W3eTaVeSdkAeJietQyMJe8f4FsIdmvfGYHkc2QHW1q89pZc6FZd0P7W0RMLduqa2W1ug7TwWRp5myyqv5R8kJ5X2s5by9JbyWHL55PDu38E7nU+Z/J4PIUOTO5/vo7s6e5DzmT9tvkqJM/k527p5DBvKWx7U1pjSBrV9eQJe/3R8Tt5bUzyLWRtoyIJyr/Z5lo0zDieeStMbR8I/I7MoUcmn8c2Xx4OjmQ4dPk8h8/jlnDOQea1sjIJdMbaa5Nlm6vJwsMo8mmnL+UdK5t11pYkt5MNsl9FngEOIPs8zqKbI55K/BSRPynLLn/fOQS5m1T1vi6kjzH25F9PdeS3++dyJWQpwD7krcXeLCd6bdK0mvJvpv9yc9oOXIB1D90NOFeR9DB+kd+af8EfJyc/Xls5bVanXjM3kxzOtl08nNyqepjyS9n7TQ6cB7WI0t9jRFJryZ/6J+gxZE/fZ0b8oe6ank8iiz1XkOOivo7OWmu3Wk2/l2DvGicQGWoaHm/tfsY2pDP7cj1mX5IzsPZgiyhf5asEdxONq0eTl58BzS8nAxCjaHrO5KFhUnlOK8p6R7L7E167aoB7kY2Cb+lcVyyE/gXZCGisQbd+xv7dPBcn0U2YY0kg8U3ycELG5c8fZ4e9YH0cf1ofGYj+nhtYbq0mkXXT8Rg/SsXrMbohv3Kl6kxD2ELclTQMW1K681kyXdJsnP0wPLFvZEs/SzRw/PQ/GVchey8vYWyxDw5CutCslbQcptw5SK+HfAg2TRzOpUgRQ6x/CzZfLZoqxewpjQ/TRYaliKb6q4nS9w9b64gmym+x6w5GqeS66htXp6PI0uc25I1trUGePwlyZrwOWQTYmORvh+QI5GWJAsOvyT7Ytq6nDnZp3MjsHF5vkj5dydy5v3byvMDyXt0tHXuSR/fh4XI2siY8p37M9l01QggowbBd+KDZPPaucyaE9ToG+l64bOnJ2Ow/JUfycmNCyLZrPQkpaOSLJVsQZZIBjy0s48L85fLxfADZLv7W8k26B3IWknL8ytqnodqH8hG5JIrKj+s04GrmRVIxtLGUVjlAnZxuWi+ngxQZzYulmWf1ch2+ZFtSnNnspb1brKd/bzyXVi1XDRPbFdaNfO3WPmO3E9ZFbZs/wjZrPKG8nzlcu4GdIMvcu2zS0tw+BpZ8m8s8rk1WVA4ngyuqwObdOA9LkPWdNYpv4FTyaAyhezMf5JcYv8WOj+cW2QJ/uPlfNzDrNrR6xgchYqjyL6qtct5+h2zJnz25n4lvT4pg+WPWUuM7FSeTy4fUOOiuSDZmTx2gMetXpg3Kz9clYtm4+53jzCrGasnX4SmPH+QHD55Ptm5KbL0/zGylL5qm9MbWS5mT1I6V8lmtJMpJeSybSeyibHWiqPkInSrkSOclisXp9eQtZG7yNrnBWTta3wnLprzyN/ryNnYY5jVVLES2e90CZV5H+QS3htUni82wLQmkPNKDieD0HrkYIEfVPbZkizwnNip72X5bh1XvlczyMLVwWSh7czyeDm6uEJD+RyeoHTm9/KPymoDZGvJyWTt8EPkZNuTyObMng0z7ukJ6vUfsw/bPY28F8DW5fmpZAmo5VE45KTEX5FV0Hsok37IoZLTqcy+7sV5qDzerQS2RcsX9p/lYrMA2el8Mm2Y9Mis5oNGe/eiZBPKNZV9NiwXyzXL8/HUrKWRNZw7yQmjjbsNjiVrHv9HlojXJZsvzh3oRbkN52OBcm5fLhfPyygl33LROIycSLhX8/+rkdaSZN/KQU3b1yGD1dmVz+dNnb5AkUvnbE4unlidg3IZpS+u23/ksOlTu/096ONzaiwttDM5wGC58j39BVlza9wb/SayxaD7fXa9OkG9/mu6cFZv/nRU+fI2bht6JtnENKBmDSr9GuSM6x+QVeVjyvGqw4XXB1YcBOdhi3KhXoEcoz+1bL+JLKkPeD2weaS9C1nTOLU8X5xsRqhObGtc8Gu39Zb39AdmDdusvucJwC3l8WvJYN7W+7APIJ9vJJuudiaHal5TAstaZG3tg2QT0wqtfA5krfrLlMEDvLK0uxbZP/eFXpyDSj72JJdt6UgfSD/SX5McZNHLIDKGvFPlr8j+oMaQ9glkzX05crRk2++bMqB89vKLMhj+yOr8NWQ/SGN+wFHlQ2o0bQ2oM41sPz6TWZ2Fq5GT8T5Ktv82OvD3psXF8drw/hslzn3JGfiNyXXnUEq9ZHPDb2hjMxZ5/+vflx/B7WTT2YLk+PZrgO9U89diWu8Bzi6PFyCD9qHkTcQWLoHrZrJjuiMLOA4grx8lV4GGHFb9BHmjsxPK83bUApcml+rYtbKt0TG7PNlH8mV6sJQHOeflaLLW2OuZ4D0JILyykHMgubT7l5h1w69lyFFjXyRXzBjQYIp2/83X80QkHUR+SPuTncYzgCsi4luSTiSbO46PiOcGeNwNyar5y+W4j5Mjjp6PiA3LPvuRF7e9ox3LMQ+QpHVj1lyIzcgO1I9HxG2SFiLbwRcnl3FfhyzFPzHHAw4s7deRfU63R8RZkl5FDuW8j6ypLUKWQG9rU3pvIkccnUZOmluU7Jj8LXmviyPImciPNc5Jt1XmZmxFlsLPJWsE55A118OAS6PGvWnmkN6hZB/dOeUzHxE5B+PNZGD/UPTmfhiLkiPN7o2I6d1Ov9f6mndT7iW/C9lXd0FE3FXm8DwHPBsRj/cgq7PyNz8FkcZkqvJ4EfLCeRFZI3grOSJkJ/J+FN8e6IQySUtHxFPl8evLcRchhwYuT9ZCPk+2Y24LvDs6PRGo73zuRNa0diTnH7yfDKQ3AKdFxL8lbUA2r0wkb2RzR5vSXpBsNjqVrBWcFBH3lPtE/BC4KyIObUdalTQXI2seB5L9T2dT7opH1rIOanwvBgNJ15Hfw6Mj4pyybZGIaPnmTpU0RpMl/uXIe9fcSDZnXkIOZf9Bu9Ky/mm6b8ox5AjJv5PNVYuTv9MlgX+QgyGOih7ct2Q2vawGdfOPvHDvQrbrH0mWPBcho/v3Kvv9llz2YEBzNchOrz+SF6iNyWr5GPJi+cnyeG3yi3AcZXx3D87D7uTw1TeV541RQPuRAe7dvLJzs519IKuT823GkKOiziabaRrzcRajgyOiKM0BledvKudixXa+zxr5WqDp39XJ5opx1e0dSHcFsp/lbnIJ/5vo8GQ+//Xrc9m6fC93Kr/Jm8gmrDFkU/uNdOA+PXX/5puaSCkBf5Zsi1+MvDvZA5JWIz+wt5BD6A4hx+QPqIooaX3yw36BbFM+ipwDsia52uxo4Nzo4VIJ5daZtwM3RMR7Ja1Czo04nmxbPZAc3ngXcHkM4K6M80i30VQzqqS1JlkzWJ5s5/8n8PWIuLcd6fUjPwuSc3I+Sa4O/P1upFtJv9p09Wg0LXNTPqcvAT+KvP1up/OzAtn0unBEzGjXUiY2cJJ2J4c1XxNl+RpJnyFriW+JvFtlW2ulrRr291iv3Jv5RbIDdVly/scjkhaOiD+TF5MLyDbzjw40gJTj30YOSX2evCjuSP4wNyLb4Y8Fjpa0UCNP3RYR/yDbu18r6f+RK9X+MCLui4jnyQvXg2RJeNFW0pK0YgnQkKOjiIgnydnhvyOb0x4hO3BHAV1pTioBZBPy8zi52wEE/nuf8t3JkVaNc1T9rv6DbGbtSp9ARDweETMjYkYjf91I12Z95hV/JofSbyZpaYCIOJ4chHJ1Weft+e7mcu6GdU2kqY1xGXKUw9Jk0Hge+GREPFw+rJfIUVOt3g96Y3KC3lERcVnlntQ7At+NNi5SWFfpSP8q2f+we9m2cEQ8Xy6yr4rSt1Pz+GuSHeWnkXehu5EsWX24vD6a7DheimxG69g9seeQvwXJYd2P9aLUXRYQ/B55p7l7ykCDpSLiN+X1ti3yaYNX0/VpM3JgxwOSViVXIPgJcFHM6mddPto0uKWdhm0QafqAPki29V9PzgO4h/yQ/gY8TY6G2Tja1ElVAskPyU7j89txzHYrX9pzgC9HxBfKtv8OPGjhuOPJC+RZEXFp2bYS2Rfy1Yj4dNl2PNlx/7GIuLWVNIeaco4uICe2voFc/2pT8h4h3+ldzqwXJB1H3sL2AbJ2fi45L+h88hYLnyu100Fp2DZnVQLIm8n2xA+Xl95L/mAPJof0LkXOh2jbKIeIuIXsaP+CpPe267itqladI+ImcoDBfpJOKNva0aS0DdnncqmkBSRNJEd4XUU25x0n6QByldiT5ocA0jjvklaTtCzZZHg1+R35QUTsRo7AeUOvmjqte8ow5sbjPcj5aFuRrSHbkUvfvEj+PtcmA8qgNexqIk01kHXJKuFJEXGR8n4BbyOXuvhhRHy/MT6+Q3nZAHiuWx3GTWlXz8NI4OWIeLn5/Up6I7km1tuAp1ptOpnDnIz1yeatLcmRQIsC356fSt2SdiYHWvyeXHL+XRFxf3ntDWTN+KiI+HHvcmmdpsp9U0pT+tZkP8huZG3kRHK1gsfK4xltKtx1TqeHf/Xqj2zXh1xU7wFmDZdciZzodgY9WquqC++9OuP1GHIZl/OZdYe+5vtCtO3WmeTIt6PJ+1x8kwwcy5C3Wz2L7DRUcz6H8x+5KvBt5VyIHLn3KBlMViVHB+7W63z6r+Pfg//eN6XpNzqSLEQ07lV/bvmttG2V7I6+r15noEMf1lbk0t6NwPFRclmLV5fnYxgEyzp34Txszazx5meR7auNZU06usQ5s8/J2Jpc6LCnczK6eO6rF4llyZFvCzBrLkhjeDGV7+mwPy/z6x+z3zdloVKgWrl8Lz5TAswHqteuofA3LPtEIuLn5HyICyWNjYj/Ry6m9gNJ4yPisejCrU17qQwhPQa4JCKuj4hjyKa9ayWNiQ5XkaOMcpO0YKnCnw2cHhGPRvkVDUdljgcREZX+jZfJtu1jo4y6Im8+tljlMcP5vBjPk/0c/1aulvFh4LvkDbDOJ1er/hY5TeCQiHioVxkdqGEVRCRtJmkbgIh4H3nviSskrRIRHyeXdBiWHZf9HG/+P+TKqFeWTu+OnovBMCejmyQtDPy2LFnRCCQjI4do7gscI+lzkg4nJ1v+vLFfzzJt3fIUOTr0M+T8n/FkADme/J2+ISJOAw6PHiyF1Ioh3bFemfkrcv7HyUCQK8D+suzzA7LdefuI+Evvcts5g3m8ea/nZHSbpM3JEuYpEXFh2daYgzOKXDX638BtEXF9D7NqXSZpcXIx07HknLHny/ZLgZ9HxOW9zF9dQzaINF04F4lcNHBZslN3BDn66meS9iFLfe+KHqxK2k1Dfbz5cFGGNf8IODEiLtSsFXJfB2wYEV8v+w37oGpzJ2lPcv24d0bEn3qdnzqGZHNWUwA5ErhK0o3kyrjnk+OtD5b0JTKA7D8cA8hwG28+XETENMraXJIOKwFka/LmQjMr+zmAzKeUywIdTS7QeuBQDSAwhGsiAJLeRkbxd5NzP84jm7SuJldo3YFcSLDnS42027Acbz7MlBrJVPImW28iR2N9u7e5ssFAw+i+KUOqZCppe2DziPhY2bQE8OOI+CPwx9J09W3gjoi4gbw/xrAjaTfgdHLocmPRvJ+WSYXrAYdFxHRJfyBrJc85gHRfREyTtCvZJ/XeyHvUuAnLiIh/kXcSHfKGRBApHecjybWexpaOypPJpoG3NDouI+I3kq4lh1QOS5LGkPcjOTgiblGuCrwgObDgUXIF4W9JupBcbuSd3epEt9mVz2jFiHjGAcSGoyERRMoP70VJHyJvO7uypM9ExPGlY+pySZeRC9k1lt0YrprHm08mFzJcmLwv9YfIQDLkxpsPY8/2OgNmnTLoO9aVN8xpeJC8PeQ1QEj6WES8h1xSYkdgV+AdEfFw93PaNcN2vPlw1ah9uBZiw9Gg7lgvfSBfJ29g9AXgL8A+5Aqw55B3IXw4Ik4p+y9a2hqHteE63tzMhp7BXhN5glwa4mCylvG/5I3r7yBrJWcCa0k6o+w/aG4Z2UkR8UxE/DoivlEJIHuSneq/7G3uzGx+Mqj7RCLi9jJM8qfkAmYXA58DXg88Gbm8+6nkzaXmy+YCSSuSS64fwhCesGRmQ9OgDiIAEXF3mRNxA3B7RLyx3H/hhfL6nT3NYO89BdwH7DHUx5ub2dAzqPtEqiRtQt5y9rgot101M7PeGvQ1kYYyB2Q74BZJL0fEl3qdJzOz+d2QqYk09PKWs2Zm9kpDLoiYmdngMdiH+JqZ2SDmIGJmZrU5iJiZWW0OImZmVpuDiJmZ1eYgYtZGksZIulLSnyTdJWmqpK0kfbO8vn5ZgcFsWHAQMWuTcvO0a4CfRsTqETEB+DC5rNs7ym7rAw4iNmw4iJi1zzbAixFxYWNDRNwGPCzpD5IWAk4D3inpNknvlHSfpNEAkhaQNF3SqN5k32zgHETM2mdt4NY5vRgRLwCnAFdFxPoRcRXwFeBdZZftgd9HxJMdz6lZmziImPXWF4H9y+P3Al4TzoYUBxGz9rkT2Ggg/6HcyvlxSdsCmwLXdSJjZp3iIGLWPj8BFpZ0SGODpI2BVSv7PA0s0fT/LiGbtb4REf/peC7N2shBxKxNyp013wrsUIb43gmcCjxS2e1GYEKjY71smwIsjpuybAjyKr5mPVZuAX1WRGzZ67yYDdSQuSmV2XAkaTLwAWaN0DIbUlwTMTOz2twnYmZmtTmImJlZbQ4iZmZWm4OImZnV5iBiZma1OYiYmVlt/x+491jBePbiaAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAFOCAYAAAB3xTGMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3Xn8pXP9//HHc2bsW4bJMoxd9iVjKSlLGNtQkRFRiVJSoaiElNDyjaSQLSSKH0aRr50WhSyFZEhMJNs3yhZevz9e79NcPn1mrjPzOdc5Z2ae99vtc/ucaznnel/Xuc71em/X+1JEYGZmNi3Dep0AMzPrfw4WZmZWy8HCzMxqOViYmVktBwszM6vlYGFmZrUcLGZCksZI+qek4TP4/s9LOq3T6Sqf/RVJT0r6WxOfP70kHSnp3F6nwwY3vefLzPB91qVR0kOS3tnNNHWCg0VDygnxgqTnJP2fpF9J+qikIR/ziHg4IuaPiFfbSMemkiYPeP9XI+LDQ03HINtaGjgIWC0iFu/057ex/f/aV/vPcXmtZDCek3SfpA926HNn+HjXnS/+PvuLg0WzdoiIBYBlgGOBQ4DTe5ukRi0DPBURfx9soaQRXU6PTfFoRMwPLAh8Gvi+pDf1OE3TPF9mRrPyOe5g0QUR8Y+ImAjsCuwlaQ0ASXNJ+oakhyU9LulkSfOUZfdK2r71GZJGlOL6myUtKylaJ6akD5b1n5P0oKSPlPnzAVcAS5Zc5T8lLTmwmCxpvKS7SwnoekmrVpY9JOlgSXdJ+oekCyTNPXAfS7H6qsq2zqqkc29JDwPXtrm9z5Tt/UvS6ZIWk3RF2b+rJS08yPYH3deyeE5JZ5f33y1pbOV9S0q6SNITkv4s6YCpfY9ln75b0vJPSb+UtLik4yU9I+mPktZt57MlbSDp1+UYPCbpO5LmrCyPUhK9v3z2SZI0tbS1K9LlwNPAWpXtrSLpKklPl5LHeyvLtpV0Tzl+fy3nw7SOd/WYLVSO/ROS/iLpMEnDBjtfBryv0e9T0nLl2A8r06dJ+ntl+bmSPlX5zInl2EyStE9lvSMlXVjWfxb4wCDben/Z96ckfWFq303fiwj/NfAHPAS8c5D5DwP7ldfHAxOBkcACwGXAMWXZ4cAPK+/bDvhjeb0sEMCIyrIVAAHvAJ4H3lyWbQpMHpCGI4Fzy+uVgX8BWwJzAJ8FJgFzVvbjt8CSJZ33Ah+dyj6/bluVdJ4NzAfM0+b2bgYWA0YDfwd+B6wLzEUGnCPa2X5lX18EtgWGA8cAN5dlw4DbyrGeE1geeBDYeiqffxbwJLAeMHdJy5+BPctnfwW4rp3PLp+xETCiHKd7gU9VthXAT4E3AGOAJ4BxM3gu/ue4lHSNB14D1i3z5gMeAT5Y0vPmsp+rl+WPAZuU1wszjXNrkG2fDVxKnt/LAn8C9m7n/V34Ph8G1iuv7yvrrlpZ1jo+NwDfLd/5OuW72KKSnn8DO5Xtz8Prf1+rAf8E3k6ev/8DvMIg14Z+/3PJovseBUaWXOI+wKcj4umIeA74KjChrHceMF7SvGX6fWXef4mIn0XEA5FuAP4X2KTN9OwK/CwiroqIfwPfIE/4t1bW+XZEPBoRT5MBbZ229zYdGRH/iogX2tzeiRHxeET8FbgJ+E1E3B4RLwEXk4FjevwiIi6PbOM5B1i7zF8fGBURR0XEyxHxIPB9pnwHg7k4Im6LiBdLWl6MiLPLZ19QSds0P7t8xs0R8UpEPAScQgb6qmMj4v8i4mHgOqb/uFctKen/gBdKug+MiNvLsu2BhyLizJKe3wEXATuX5f8GVpO0YEQ8U5bXUnbA2BX4XEQ8V/bzm8D7h7Af0Lnv8wbgHZJa7SUXlunlyOq6O5XtKm8DDomIFyPiDuC0Afvw64i4JCJeK+d41c7ATyPixnL+fpEM1DOdWbZ+rY+NJqsARgHzArdVahdE5paIiEmS7gV2kHQZmRsc9CIpaRvgCDLXPqx87u/bTM+SwF9aExHxmqRHSjpbqj1Vni/vmR6PTOf2Hq+8fmGQ6fmnc/sD0z+3sgpvGaZcRFuGkwFqatpN2zQ/W9LKZC5zLPl9jSBzxdNK96D7LemflcnVSnAZ6NGIWErSXGT72eZkybaV1g0HpHUEeSEGeA9wGHCspLuAQyPi14OlZYBFyRz+Xyrz/sLrv+sZ0anv8wbydzUZuBG4ngwCLwI3lXNzSaCVmavuw9jKdPX8HmjJ6vKI+Jekp6axft9ysOgiSeuTP5RfkMX8F8ii/l+n8pYfAbuRAeCeiJg0yGfOReYC9wQujYh/S7qEDDyQ1RnT8iiwZuXzBCwNTC1NM6Kahia3N71DKD8C/DkiVurAtqf3s78H3A7sFhHPlfrxnaey7jRFNly3u+5Lkg4B7pO0U0RcUtJ6Q0RsOZX33ALsKGkOYH/gx+R3Vne8nyRLJcsA95R5Y2j/u276+7wB+DoZLG4gf5cnk8HihrJOqyZggUrAGLgP00rnY0C1TW5eYJE209dXXA3VBZIWVDZWn0/WZf4+Il4ji8jfkvTGst5oSVtX3no+sBWwH1OpgiJzbnOR9aivlFLGVpXljwOLSFpoKu//MbCdpC3KxeAg4CXgVzOyr21ocnt1+zrQb4FnJR0iaR5JwyWtUYL6UNV99gLAs8A/Ja1CfsddEREvk9VBh5dZPwVWLg2xc5S/9SWtKmlOSbtLWqhUGz4LtLpsT/N4l2qiHwNHS1pA0jLAgUC790k0+n1GxP1khm0P4MaIeLZs8z2UYBERj5Dn5jGS5pa0FrA38MM203QhsL2ktyk7MBzFTHrdnSkTPRO5TNJzZI7nC2S1Q7V/+yFk4+7NpSfF1cB/ujNGxGPAr8n6/AsG20DJ7RxA/iifIds2JlaW/5EsoTxYen8sOeD995E/lhPJnOAOZJffl2d8t6euye3V7esg679atr8O2VD9JFkf3e7FaSiffTD5XT1HZhoG/X4bdAYwRtIO5Rzaiqzbf5Ss5jmOzIRAVs08VM7Rj5LfX7vH+xNkh4YHyZz7eWXbtbr0fd5Adt99uDItstTXshvZOP8o2d5zRERc1eY+3A18nNzvx8jf6Ex574gi/PAjMzObNpcszMysloOFmZnVcrAwM7NaDhZmZlbLwcLMzGrNMjflLbroorHsssv2OhlmZjOV22677cmIGFW33iwTLJZddlluvfXWXifDzGymIukv9Wu5GsrMzNrQaLCQNE45Nv4kSYcOsvxA5Tj5d0m6pgwH0Fq2l3Is//sl7dVkOs3MbNoaCxZleOKTgG3IMd13k7TagNVuB8ZGxFrkGCpfK+8dSY6iuiGwAXCEBnngjZmZdUeTJYsNgEkR8WAZ9+d8YMfqChFxXUQ8XyZvBpYqr7cGrirPeXiGfKLWuAbTamZm09BksBjN68d5n8y0x7Hfm3yM4oy818zMGtRkb6jBnhc86KiFkvYgHybSelJYW++VtC+wL8CYMWNmLJVmZlaryZLFZPIBKS1LkUP8vo7ywe1fAMaXxw62/d6IODUixkbE2FGjarsJm5nZDGoyWNwCrCRpufLQjwlUnrMAIGld8tnD4yPi75VFVwJbSVq4NGxvVeaZmVkPNFYNFRGvSNqfvMgPB86IiLslHQXcGhETyUcazg/8pDyH+uGIGB8RT0v6MhlwAI6KiKebSqtZr31z1+2H/BkHXfDTDqTEbHCN3sEdEZcDlw+Yd3jl9Tun8d4zaPOJWmZm1izfwW1mZrUcLMzMrJaDhZmZ1XKwMDOzWg4WZmZWy8HCzMxqOViYmVktBwszM6vlYGFmZrUcLMzMrJaDhZmZ1XKwMDOzWg4WZmZWy8HCzMxqOViYmVktBwszM6vlYGFmZrUcLMzMrJaDhZmZ1XKwMDOzWg4WZmZWy8HCzMxqOViYmVktBwszM6vlYGFmZrUcLMzMrJaDhZmZ1XKwMDOzWg4WZmZWy8HCzMxqOViYmVktBwszM6vlYGFmZrUcLMzMrJaDhZmZ1XKwMDOzWg4WZmZWq9FgIWmcpPskTZJ06CDL3y7pd5JekbTzgGWvSrqj/E1sMp1mZjZtI5r6YEnDgZOALYHJwC2SJkbEPZXVHgY+ABw8yEe8EBHrNJU+MzNrX2PBAtgAmBQRDwJIOh/YEfhPsIiIh8qy1xpMh5mZDVGT1VCjgUcq05PLvHbNLelWSTdL2qmzSTMzs+nRZMlCg8yL6Xj/mIh4VNLywLWSfh8RD7xuA9K+wL4AY8aMmfGUmpnZNDVZspgMLF2ZXgp4tN03R8Sj5f+DwPXAuoOsc2pEjI2IsaNGjRpaas3MbKqaDBa3ACtJWk7SnMAEoK1eTZIWljRXeb0osDGVtg4zM+uuxoJFRLwC7A9cCdwL/Dgi7pZ0lKTxAJLWlzQZ2AU4RdLd5e2rArdKuhO4Djh2QC8qMzProibbLIiIy4HLB8w7vPL6FrJ6auD7fgWs2WTazMysfb6D28zMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVqK1hIerek+yX9Q9Kzkp6T9GzTiTMzs/4wos31vgbsEBH3NpkYMzPrT+1WQz3uQGFmNvtqt2Rxq6QLgEuAl1ozI+L/NZIqMzPrK+0GiwWB54GtKvMCcLAwM5sNtBUsIuKDTSfEzMz6V7u9oZaSdLGkv0t6XNJFkpZqOnFmZtYf2m3gPhOYCCwJjAYuK/OmSdI4SfdJmiTp0EGWv13S7yS9ImnnAcv2Kt1175e0V5vpNDOzBrQbLEZFxJkR8Ur5OwsYNa03SBoOnARsA6wG7CZptQGrPQx8ADhvwHtHAkcAGwIbAEdIWrjNtJqZWYe1GyyelLSHpOHlbw/gqZr3bABMiogHI+Jl4Hxgx+oKEfFQRNwFvDbgvVsDV0XE0xHxDHAVMK7NtJqZWYe1Gyw+BLwX+BvwGLBzmTcto4FHKtOTy7x2DOW9ZmbWYe32hnoYGD+dn63BPqqT75W0L7AvwJgxY9pPmZmZTZdpBgtJn42Ir0k6kUEu1hFxwDTePhlYujK9FPBom+maDGw64L3XD7L9U4FTAcaOHdtuIDIzs+lUV7JoDfFx6wx89i3ASpKWA/4KTADe1+Z7rwS+WmnU3gr43AykwczMOmCawSIiLisvn4+In1SXSdql5r2vSNqfvPAPB86IiLslHQXcGhETJa0PXAwsDOwg6UsRsXpEPC3py2TAATgqIp6e/t0zM7NOaHe4j88BP2lj3utExOXA5QPmHV55fQtZxTTYe88AzmgzfWZm1qC6NottgG2B0ZK+XVm0IPBKkwkzM7P+UVeyeJRsrxgP3FaZ/xzw6aYSZWZm/aWuzeJO4E5J50XEv7uUJjMz6zPttlksK+kYctiOuVszI2L5RlJlZmZ9ZXoGEvwe2U6xGXA2cE5TiTIzs/7SbrCYJyKuARQRf4mII4HNm0uWmZn1k3aroV6UNAy4v9w78Vfgjc0ly8zM+km7JYtPAfMCBwDrAe8H/IwJM7PZRLsDCbbupP4n4EesmpnNZupuyjs+Ij4l6TIGH0hwekeiNTOzmVBdyaLV4+kbTSfEzMz6V91Nea27tkcCl0fES80nyczM+k27DdzjgT9JOkfSdpLa7UVlZmazgLaCRUR8EFiRHGX2fcADkk5rMmFmZtY/2i4hRMS/JV1BNnTPA+wIfLiphJmZWf9oq2QhaZyks4BJwM7AacASDabLzMz6SLsliw8A5wMfcSO3mdnsp902iwnA7cAmAJLmkbRAkwkzM7P+0W411D7AhcApZdZSwCVNJcrMzPpLu11nPw5sDDwLEBH344EEzcxmG+0Gi5ci4uXWRLnP4r+G/zAzs1lTu8HiBkmfB+aRtCV5v8VlzSXLzMz6SbvB4lDgCeD3wEeAy4HDmkqUmZn1l3aHKH9N0iXAJRHxRMNpMjOzPjPNkoXSkZKeBP4I3CfpCUmHdyd5ZmbWD+qqoT5F9oJaPyIWiYiRwIbAxpI+3XjqzMysL9QFiz2B3SLiz60ZEfEgsEdZZmZms4G6YDFHRDw5cGZpt5ijmSSZmVm/qQsWL8/gMjMzm4XU9YZaW9Kzg8wXMHcD6TEzsz5U91jV4d1KiJmZ9a92b8ozM7PZmIOFmZnVcrAwM7NaDhZmZlbLwcLMzGo5WJiZWa1Gg4WkcZLukzRJ0qGDLJ9L0gVl+W8kLVvmLyvpBUl3lL+Tm0ynmZlNW1tDlM8IScOBk4AtgcnALZImRsQ9ldX2Bp6JiBUlTQCOA3Ytyx6IiHWaSp+ZmbWvyZLFBsCkiHiwPJL1fGDHAevsCPygvL4Q2EKSGkyTmZnNgCaDxWjgkcr05DJv0HUi4hXgH8AiZdlykm6XdIOkTQbbgKR9Jd0q6dYnnvAzmczMmtJksBishBBtrvMYMCYi1gUOBM6TtOB/rRhxakSMjYixo0aNGnKCzcxscE0Gi8nA0pXppYBHp7aOpBHAQsDTEfFSRDwFEBG3AQ8AKzeYVjMzm4Ymg8UtwEqSlpM0JzABmDhgnYnAXuX1zsC1ERGSRpUGciQtD6wEPNhgWs3MbBoa6w0VEa9I2h+4EhgOnBERd0s6Crg1IiYCpwPnSJoEPE0GFIC3A0dJegV4FfhoRDzdVFrNzGzaGgsWABFxOXD5gHmHV16/COwyyPsuAi5qMm1mZtY+38FtZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKyWg4WZmdVysDAzs1oOFmZmVmtEkx8uaRxwAjAcOC0ijh2wfC7gbGA94Clg14h4qCz7HLA38CpwQERc2WRazaw/HHnkkX3xGfZ6jQULScOBk4AtgcnALZImRsQ9ldX2Bp6JiBUlTQCOA3aVtBowAVgdWBK4WtLKEfFqU+k1M6u65toVhvT+LTZ/oEMp6Q9NVkNtAEyKiAcj4mXgfGDHAevsCPygvL4Q2EKSyvzzI+KliPgzMKl8npmZ9UCT1VCjgUcq05OBDae2TkS8IukfwCJl/s0D3jt64AYk7QvsCzBmzJjaBC176M/aT/1UPHTsdkP7gCMXGnIaOPIfQ/6INX+w5pA/4/d7/X5I7793lVWHnIZV/3jvkD/jpI9eO6T3f/zkzYechoMu+OmQP6MTJh9605Dev9Sxmww5Df1ShdQPJYPFr7tjyJ/xt83W6UBKmi1ZaJB50eY67byXiDg1IsZGxNhRo0bNQBLNzKwdTQaLycDSlemlgEento6kEcBCwNNtvtfMzLqkyWBxC7CSpOUkzUk2WE8csM5EYK/yemfg2oiIMn+CpLkkLQesBPy2wbSamdk0NNZmUdog9geuJLvOnhERd0s6Crg1IiYCpwPnSJpEligmlPfeLenHwD3AK8DHO9ETasjtDWZms6lG77OIiMuBywfMO7zy+kVgl6m892jg6CbTZ2Zm7fEd3GZmVsvBwszMajlYmJlZLQcLMzOr5WBhZma1HCzMzKxWo11nzaalE+M6mVl3OFh0WwcGATQz6zYHC5vtdWLUWLMmdGrE2E5wm4WZmdVysDAzs1quhppNDfXBRTZr6sTDi2zW5JKFmZnVcrAwM7NaDhZmZlbLwcLMzGo5WJiZWS0HCzMzq+VgYWZmtRwszMysloOFmZnVUkT0Og0dIekJ4C9D/JhFgSc7kJyh6od09EMaoD/S0Q9pgP5IRz+kAfojHf2QBhh6OpaJiFF1K80ywaITJN0aEWOdjv5IQ7+kox/S0C/p6Ic09Es6+iEN3UyHq6HMzKyWg4WZmdVysHi9U3udgKIf0tEPaYD+SEc/pAH6Ix39kAboj3T0QxqgS+lwm4WZmdVyycLMzGo5WJiZzeIkaaif4WBhNovpxIXBZjmLDfUDHCxmYpKGVf/PbCS9SdK65fUMX+AkLdG5VHVGNy/YA7cVXW6IlLR+N7fX7/opWCstCvxE0nxD+ayZ8iLTbf305QNImgMgIl6TtCFwRJk/U3yf5QQeDhwAvB9m7AJXPmdh4GZJe3c4mUMSESFpfUlv7ca2ACTtJel4SZ+X9Jamt1vxkT4N2CtLWqXL21Tl+5ijm9seTKQnga2AzSXtPqOfNVNcXHppwJd/gKSTyo+x9vb4htKzGPAJSWuWWesC/4QMHr1I0wxQRLwKHAOMlbTRjHxI+SE8A+wNfFbSnp1M5FCUYLg+cPyM7t90bu8jwMeBO8qskyRt0fA2BRARHwZWkvSLJrc3PSTND3wMWKFMN36tkzSscq34JPD/JB1SMnRdV83kRsQL5PX+LEnvnpHPc7CoUfnyNwF2A24lx2I5tVy4u21BYCNgR0lLA/MAL5Q0/icn02+loRZJqwPjJa0VEZOB64AlyrIZOh8j4moyYBzZy4Ax4Mf5KnAucDrw1U7n9EswqhoDHBIRZ0XEV4FvAvtKWriJc6GaiQKIiBuBEZJ+2ultzYiI+CfwJ+CLkkZ2IyPV2kYpTW4GnA/MCexXrh9dMyCTO5+keSPiUmA8GTB2nt7PdLBog6T3AYcDR0TEmcBxwB+B73az+F1OgPvJaqflgO2BpYAVSuBYqxS9R3a73npqJM0raePyeg3gk8CbgTMl7QSMAD4jadEZ+UFL2l7S+yPiF8Ce9DBglKqnjSSdUqafBX4I/AT4Uqfq9iWNBFYrr7eXtCSwJPDBymq/BF4GXuz0uTDgQrR26/uNiI2AOST9vJPbm860rSRp+5Ke75KZkQ3KsoEBtlPbXKVUhyJpW+AK4LSI+CEZMG4DPiRp8ya2P5jK93MwcDLwM0lrRsQVwHuBU6a7Sioi/Dfgj3KzYmV6TeA+4MTKvDcC3yYvBsO7lSZgzvJ/aeA04G7gV8ApwM+BS4GNe30MK+keCZwJXAJcDyxf5r+NrIY6CXgWeF+ZP2w6v5sPAP8LvLfyufcB+/ZgXzcA3k5WBZ1cmb8ycANwI7DQwH2Yge2sTpYczgHuBwTMD/wCOL6sM6Fsb5EG9/ez5dz7TTkXtynz/xf4ZQ+Ov4BDyAv0RLIEfjJwVIPbHAF8o3qcgZuA31amly/H6mRgni4ej/2Ba4A5ynd0P/COsmw88DCwQLvnY1e/zJnhr3rggLcAawPzAaOBe4CDK8tHAaO6lSZga+DH5QL73nISfB84slxABMzd62NY0roCsFt5vSvwD+C8AevMTVajfRO4cDo/f83K6wnAZcCEMr05cDuwUBf3d2XgZ8DiZIn9JjKAi2y7+A6wegfPzcOB54BPVuYtAdwMnEfmZtdocH9XIoP/cLKqZW8y87RYWX45sHQXjnvrt7E6sAaweJn+TLlA3wr8HyWQdXjby7d+/+U7PhWYq0zfBPy8su6ywMLdOBaV6UPImoeDy3Xjs8ATwBZl+XzT9flNf5kz6x9wIPBrMkd8AbBdOfB3AYf1ID0bA78HdgF2BP4KfJTMqZ5XAkbXci1tpHcFMme3YPmh7Ejmco6prFPNjd3Y7sW0fPY5wKcq895PPs9k7zLdzRzciuXCfVhl3txkSe884BFg2yFuY+CFYGkyCJ9JVr+1Llrzl783dHgfB25/RTIgr1ymFyBz8wf14FzbkQyOp5UgtWGZP4zM8J0KfKLD25wf+AFZJTwGWAT4KVnKaJX+rwZu7sHxaG1f5bd3AzBHmfe7cl7OPfA7rf3cbu9Iv/6R1SWtg7wcmUObr8zftASNVcncyy3AyC6n793A0ZXp5cgqqBVLutbq9TEs6VqhXLxWKj/WP7cu6iWdN5CBbTUy570wWc03CViizW3MAbyHLGHtX5l/abk4z9/F/Z2//D8ReKq6bbKKYoXWBXUI26iWKD4GnEAGxxFkafMCMhNxOPBdYESH97G6/TdSAjHwVeDTTKlaPIjMzQ6b3gvRENK2FFmimw/YvVwMFy0XymFlndXJjN+iHd72umSAOgx4QzmXLwL+p3ItuQwY0/AxWI58gBHAfuUcOI6sDRkJnEVmLN5Xli0zI9txAzcgaQWy/nwzSXMCr5E/xJcj4mkyBzWJbAv4A/C2Mr8baXu7pOXI4v7bWvMj4s/AtWTR9t6IuKsb6ZkWSasC/4/84SwS2WC9C9kr54CIuJdshN0U+BFwWWTX18fIY/rYIJ+5hKQ3lNf7SvoS8AmylHI9sKqkr5TGupeBz0X2hGmcpDeRDYVrR8QnyIv2HZIWKqu8GhEPRMSfhrKdaF2xpc3IHnmPke0jXycbsk8nc9BbAqdGxCtD2V7VgMbsg8j2gF9KWgm4krwz+ExJx5B15JdGxGut93TBy2Qb1afJrsM7R95XsAlZqoUs9SxM/q6HpNpIHhG3k4F7BfKeIZHVcaPJrstzRsQOEfHwULc7jfSMJDuN7C7pw8AewIVkteinyYB2GzAO+ALZ7jpjTxTtRvSfGf7IXNk3gc3K9PfLX6v4dhSlCoWaRtghpmMxSmNvmf4hpXqGLN1cS56cmwN/ANbr9bEraVuCrCZ73yDL1iEb1z5RpkfQRm6rfOa5ZK5oj3LSv5tsrDu6HIeNyaqYqxhim0Cb+zmwOuY7ZM5tjTL9LeBvwIId3u77gDuBtcv0BmQG55uUHDMNlqjIQHQlmVM9gmxMX4usfhkP7AOs2K3jT1ajtNoHTiCrh9cr05uRpe5VyvRSlNJPh4/HemRgWKycg4eTQWkkWUW1WNPHo6RlHJlxuBDYs3UulHnfLtPDGGLJqvEd6fe/ysm3G1lFcguZg39TOQlvAz5H5l6GVJ3QTlrI6pUfAnuVeecDm1TWObWcmDcC2/f6+FXS9Vbggsp+iNdXX6xKtrMcPOB906yuIHNqZwFnAzsJL2MnAAAWTUlEQVSUefOT3VFPqKzXaNUTlY4DZFXkOyvTXy/fWevidBKwaSfOy8r08sDTZMmhNW9sOUePo8EeeWRX558Ap1TmHVICxlt6cK7tSJZgLyLbC9Ys58hpwOeBezv92yjH+rryehfyHo4zyIbsHcnOLqeRAfwNNJihLGkYNmB6E7JkeyGwUpk3B1n9tkxHttntL7of/8julzeVE+J84HvAFuWC9wGyLvRNXUrLImTvntPJKpujqeSKmFIX+obyvyt1w22k+y3AxZXpaqB4M1nXvUY7F9FBAs0Esr/8tyjtGmS99DU02DW0sv2FyIzE28v0wWSJZ/PKOheTGYu1qvsxg9ur7vvaTClZLkk24n+5snxdOtwjb2C6yZzzoWTJdrvK/CPIkm7XeuCR7Q+/JNtqjiQzIEuWNO5FVlFuMpTjP41t30yWar9F9noTmUn6HbAhmSE6iQ63jdSkaQuy5D4/sArZI+1LZKlnHFmF3pFeWF3ZoX79Y0qp4jvAxyvzjy0n5GZ0uLGwjbQsUv7vRuZW/4/MKZ1PNuD+kizm9kWQqKR/UbLf9n6Vea0qvHdTue+h3bSXE37B8nrrcoH+ELAMsBNZCuxKYzZZJ31b+WHOQ9YHnwJsWZa/k8xpr9rBbX6mfOZN5SK0Wbko/gn4ZpPnYXm9E3nfyFpk1eFny4WyGjAa7ehR9nfb8nqlcg58q7L8C+W8ayQzVwLC8Mr0T8pvcrHKvM9QujBTqsYaPB7V7+fDZJXnqWTPq1FkhuyHZLXcuXSw+3RjO9Wvf1SKb5UL9N5kL4ExlWX3kLn66eqLPJQTgKz6up8p9Y4TyCqnr5F1oYvQhXr5GT2m5WJ2I/CRyrL1yPrjzdv9nPL6Y2SX07OBL5N11NuT3f6uJbvOdrUHGNlV+c4SMOYqAeMKshro18BbO3EelNcrkze8jSDrxXclb+panKyS+kO5OHQ699w6Fz9Ztn8gWarbluxkcTDZlrf1wDQ3cLxHkD3rflS2Px+ZsbsUWL+y3peAZ8ryRqrjgHcAS5bXVwM3VJYdTamia/h4VM+PxciM09Jl+kgyI7kYWcI4lk6XOJvasX7/A95VTsRVySqSM8jeFK3i24+B0V1Mz3YlMFxULq77lPm7kjmFDw08Yfrtr/y4twQmkyWh75NtPeOn83PGlx/gGLIB+ziyO+I85bs5gy4U9Qc71mSPnzuBdcr0OLLb7Jad2hbZFXIVsgqh1U11iXJM9yjTc3R4X1ek3MRIttldSTaKHkNWwV1fvpc5yFJWtxpv5y7bO4e88W0esp3mWCqdO4AVGtr+MPKmwwvJ6unW/SzXAQ+QGYZLaDgTN+D8+BiZYbq1XDdambUjyEzuKBoo4TT+ZffjH9kOMYlsmHyGLLqtUi5QV5HF/q7l4MuXexdZ7z8fWfT/HfD+svx9lF4w/fDHgNzbwIsqmfsdX07kNw+2zlQ+dxjZOPg8cE1rW+UicSxZ3J6bLlQ9MSWHvX05T05kSjvR/mSV1MYD1h1yICfvzL+ODLzfA77IlKq4LwOHto5VB/d1YbJ66WtkN9OR5E1/e5RAMXc5/g9ROhl08fhvSWagflsuyu8ov5H/KUFj/U4fjwHpGNn6T2bmTqgEjOvJHoBv7MYxqZyPPyQzUeeWc2LdyvLPAcs2su1u7WS//JWT7QxKNz+yCuqZ1gEvP5yu3HBX+UGMpNxYVKaHlS99ErBLr49ZJb0LVV6/jczxrTBgnemqBuD1OaZWDmkNsufPgZVlbyW7L3clR1u2uV0JCuuSGYg7mdKmdCBZAlx4evd5Gtt7F1mt1erNsgV5R/AvyN5HD7SWdfj8E7AN8BUydzpvmX8w8J7y+tNl+TJdPP7LkDnlVcibOD9WfrsbkPdQfIfSA62h7W9EdjRpdVdemKwSu7ASMBqtfRjw+3gTeeNnK8OwDNmWdTSVarnG0tKtL75Xf5UfxDCyCH18uQDswZSeRR8ib9gZUp3zDKSp2kh2Oq8fS2ZHMvc0kS70X28jzQuQffr3JnM195JVA7eXi+q8M3ocyutdyXryTcv0auQ4NgdV1ulKr5ty8ZyrXIzWJBt6ryFzcg8xJbe5TCfOg8r0LsCrlE4C5ZwdCXyk/HW0EZfSeYMpQXpXstPA4WTufb/yWzmKDIyNj/VUSdtcZKeJWyrzlikX66vJTF9HSxNkA/pG5D1MC5G9rL5ClibWKussWc7Lw+nCAKKVtC1c/n8eeJQp95SMJu/pOJymG9e7tbO9+BtwMXpj+T+M7EFxAplbHV7m79HpH2NN2rYli7DfJ3sLzUf20/4NWc1xX/lBnAYs1wfHcgGy+u7b5BAGbynz9yarB7ZnBjsDkG1FvybbkJ6uXCxXIYN4R8f1aSM9S5X/C5KNyb9hSuPmX8nh6UcMvNgP4dxcshKA3kVWSb6n4X1clAx8b6yk4ZdkR49jgC+U+e8hSxXdrJZtjf01d7kQHknJKJAB7DtUBpLs0Da3I6t+Ly7B6CGym+7yZfvfIXP2m5a0NTqER/U8IUtSdzHlxs8DyJGNx5bpJSgDKDaalm6dAL38I4uvN5Ld3r5e5n2JLGV0PIfSRnrGlh/BlmS/8OOZ0qC9TwkWa5LB7Da62NA+lfS2SkILkV16b2kdxzL/A+UHttP0HksyN3d1uTDvR5ZUbqDcvFeWN3oz5IB9fBPZNXXfMr1o+a5WIXOdX2aIQ8BTKZGQVT1XlgvVAWQ31XFkHf2uDe/zDmSvqjXIktPHy/xNyTaMY+hCb8BKelolnJXJTNIbyPaqE8hB+t5LZrA27PB2x5H3ULyjMu+IEjBWLefAF8t3cjsd7B49HWlsdTRYrUx/nLznZt2upaHbO92Dg9zKMaxKjsD4K6Z0czuRrO/r5gili5Qf6Lllei6yAfsEMqi1clAblkDR04ZtXt+u0qq22KX8mPeprPdhSk6n5vOWYMqdztuRuceR5Qd7bZm/G/n0vz16cK6cSdZJ/54pw5N8t8x/lKH3etqG7B69GHnX7S3lGGxJViV8gSxltkYUmJ9mu2OOI0tvh1bmDSfvazmahofgJ0s0rYEIF67MPwf4bnm9GJm5O5ohjt47yPZHlv3fvkxX79T/UvmuWm2Jy9BwDn7AMXhbdX9Lem5hyk2a+9LhYUymmbZubagrOzN4V8d3Al8ZMO8m8q7i+eliT4bK9ncHniQHPYOs0tiLLOouU+atTKn66PUf2bPpNnI4gY+Wee8lb0rbfzo/a6XyAzyT7P63WOXzLiqvt6f7XZen1iNtZ6YM9TykXFy5AN8DbFQ5rpdXlq9PVnm16qMX6NK+b0lWrS00YP50t0NN53ZXIdtC3kNW+UwkG/LnLt/Ht6i01zGl5NHpe0u2IzMHrc4Lc1WWXU8bmaAOpWMrsjts6x6Wr5KZyC0r65xHZloaL23/V/q6vcGGD/aI6v/yeuvyQ6g2Jp9CeQBIF9LUypmvRzacLVOmW3XT1YDRF8FhQPpXJLsubs2UZ2q07lbdvVz0axs+eX0d/VHAS5Sb98q+r0IGoyvJon5XGvWp75H2AOUmySFuZyvgcbLU0ipZLVZ+/O8acG7u1IPveRuynaxbPQGXJUvYreePLEhWh11IVrn8jLwBc0IX9/8BpjQkt0YfuJQGHyI1IA2fAF4ku+9vDsxLNmh/rRJA3lV+I0t1/Rzp9gYbPNCtBrtWQ2E1YHyJfK7CTmSPm9vpQvGtciHahqwHP4zsSdEau2Y88CDlkaD98FcuYNuXi+WyZKNndfC6NUqQ+0yZrn0GxYBAsSLZuN96et57K8tWI6tFujl6abs90mb4fCG7wP6JDK4HkjcZtu7R2I/MPZ5EVuU9QBe7pw5I545kaarx51GQ456d0PouyO7J48kOEyuX4/Ibsp2gK1UtgwSMPUsaulL7UK5h3yrnyCXltzAvmWk5l7wp8xd0qXH9v9LXi402eLB3IEsRrS+7Wpz8ENkN7iy627Nj9RKcViBz54+VC8e4svxdVEaV7fVf+cGswpQbwT5NVtutx5SS29plH5at+ayBAwIeRN5H0OpZtB35/O2tyutvdHlfu9Ijjaxeemt5/Saykfy4chxHkO1TXyNv/lutx99/t8baegdTBgQ8g+wSezcZsL9fAtYKZHftjbq4/9uUc2I/sn2z0VIF2aGh1S13WDkvTiu/icvK/2Fk54rDaPC+ktq09mrDDX/Z1dxBq8F4A7KHUdM5phXKhWfHyryVySqcW8v0Z8mHtmxWWaenw3iQQ0y0BsWbl7xbeq9KeieS7Tytrsa1FxVeX7rbnewe2xpSYnT5/3aypHITXRzriR70SGNKnftKZFXccbx+jKOuDFrZD3/lHPsU2QX0QrKxv/XUxB8w5R6oH1EZZbdLadu+/D6bHsJjEbJx/WGybWx9MvNwEhlEJ5TfXV/cmDvLPSkvIq4gf+i3Slo4Il6UtD9ZN/xslG+pCZJWJus4NwYOkfTRkqY/kb2xfltW/Q2Zq3qhku7G0lVH0lzkEBOnSNojIp4nuxJuIGlCRHyN7JnzdXIQPaLmaXSSFgUmlSd5QeaOfgpsK+kwYKKkH5B3RW9Fjh/Vlaf9lbSdRV6cryID42+BNSR9DDgnIr5DXtBOJMfl+utQtxv55EAi4n6yt8/zwJ6S3lLmd+wJd/0uIp6PiOPJASZ3joibIp+aOJLMcC0uaW6ytHdBl9P2U3Jol7sb3s5TZAecpZjSZfps8rwYFRHnk8/teI+kBSSpyfTU6nW0ajBqb0PmWA8k7zZep+HtrUZWN7Ue0LMHWZRtDTi3CdnD5wSy+9sGvT5GA9K/P3lingh8sMzbnRzp9L1l+lCmo2cIWS14H9lfvjXW/3Vl/iZk76+ejKJL9r56gpJrowc90sjqvs/RcPfUmeGPHF1hWzLzUB0CfZYvbZFtWn8hSxofITNmPyQHMFyALvWKq01nrxPQ8JewHVnMa/xeBbJP9GuV6bvI+vk7yDrZ4WQu4khKe0Wv/yhF/fJ6C/LGxX3I8Yj2KvN3I3Ph//W41Da3sS3ZjrRAmW6NOzS+BNdlurCfrcbsTUrm4Z3lh7ktlbul6UGPNDo8euzM+FcCxcbkzZmtzNZ/PW1xVv5jSvvZ/GW656M2/Fcae52ALnwJjfYVH7CtbcjeTVcDh5d5c5KNwQcNWLfXbRSrkEMbfKwy75NkSWJ3spFt9zJ/D4bQ0Fd+CNV2pN1KDrIrXRLLNseRJcwPl++j1f13B/qsR9rs+FcCxuLl9WwRIAY5BtuWc3RkZV7fHIsRzOIi69+7ta0rJO1D9oPeqsx7WdJxZFVMdd2etVEUa1OqgyQtSI68+0fgX2Qf9xeAd0saERE/GMqGIuJySQH8WtJGZFXUTRExeUh70CZJC5GNljuQJYrnySpByH0dTo7maT0SEf8mn/rWD7+Nnii/kzmAqyWNzVn9cyxm+WDRbRFxjaTxZO51RUkrko9dPKC3KXu9iLhA0nPkDVCjyLaFb5ONbU+RF9E5ye6MndjeFaUh/SqyvabJjgYrkMHw1Yi4NCL+IelhsnptCbIx/TFJOwFPRcQl5X3qpx+nzX4i4lJJ10TpDNFPHCwaUHIIr0l6nrwZ8FMR8b+9TheApOER8Sr8J53zkO0o55B1+eOBJyLiJUk/aa3bCRFxiaSrGw4UK5MN9VcCb5G0REScTFaDvZscAPHhknM7jmxQbKXPgcJ6Lmp6GvaK/PtojqQtyJvbLu6DtCwZEY9OZdke5Jg8H4uImyQN68ecTR1Jq5G9SA6PiMvKfi1ADlB4n6QjyB5ObyBLUF+MiIm9S7HZzMPBogt6Xb0hqfUs5bOj9B0vbRGvVNaZUNb5aERc2ZuUDo2ktwE3RsSwMn0X+fyJ0WQbycclLUb243+qBBBXPZm1wcFiNiFpBDkc9NciYkKZN7xazSRpd+DhiLipR8kcMknbkPdzPEgGjqMkzUkOWndGRBzb0wSazaQcLGZx1ZyzpIXJwcgej4g9y7zXBYyB75kZleq/K8n7SF4r8/Ym78r9Zk8TZzaTmuWG+7AkaThko62kJSUtHTmcwnuA+SWdV5a/Wkod/zEzBwrIHmlkQ/2fACo90n7fy3SZzcwcLGZBkpYgh5tG0jjykZnnSjq+9LTYCxgh6WKYNcckiojLgf1Lj7RL6aMeaWYzI3ednTWtB3ygVDttA7yffNbHb0pPpwMkfRg4R9I6EXFHD9PamIj4uaQdyB5pP+91esxmZm6zmIWUm9G2JkdR3ZEcLG8ecujtx0vwuBm4ISL2Hay9YlY1s7fDmPWaq6FmEZJWJR+WMpp8CttFwE/K4s0kvbG0WbwVGFfuSZhtLp4OFGZD42qoWYCkxcmxjr4eEWe2xr2PiAslzUtWRYWk60sJY/lZsZ3CzJrjYDFrGAX8LiLOLNPDSrXLKxFxdmnk3a3MvxCYLaqezKxzHCxmDa8Cq0saHRF/Ld1hBSBpfbI3UAAPlNE9zcymi4PFrOHv5EB5q5PDW0A+OCaADYFNI+LrPUqbmc0C3MA9C4iIJ8lHMX5F0jslLRIRr0namHxc6m29TaGZzezcdXYmVx0hVtL+wJbkQ+7vBzYHDo6Iy3qYRDObBThYzGQGu19A0pwR8XJ5vSywGBkwnoqIO32PgZkNlYPFTKR10Ze0KbAa2S5xZkQ8Xw0YZmad5jaLmUgJFFsCJ5AP8HkLcIuk+SOf9e3v08wa4ZJFn2s9rCciflWmT6RyT4WkbwNvArbzjXZm1hTnRPtYGTr8XeToqe8os58HRlZWO4zsLjtXl5NnZrMR32fRxyLiFUnXA68Bu0v6G/Aj4BpJkyLiUmCt8rcg8K+eJdbMZmmuhupDkhaKiH+0RoWVtBJwAXAP8EVgceB04Jdku8UhEfGz3qXYzGZ1DhZ9RtJcZFD4XkR8ozRaXwg8C/wWeDNwDPAU2cg9b0Tc4+6xZtYkV0P1mYh4SdLuwMQyAODGwJ8j4iBJo4G5gS8B34+IGyrvc6Aws8a4ZNGnJI0FrgL+GBFvqcxfkXyw0ZUR8Ydepc/MZi8OFn1M0trA9eSQHadX5s8TES/0LGFmNttxNVQfK0N1bAlcLmm+iPh2me9AYWZd5ZLFTEDShsDV5BDkk1sDB5qZdYuDxUxC0oIR8Wyv02FmsyffwT3zeA5yMMFeJ8TMZj8uWZiZWS2XLMzMrJaDhZmZ1XKwMDOzWg4WZh0gaXFJ50t6QNI9ki6X9HZJF5bl60jattfpNJtRDhZmQ1R6qF0MXB8RK0TEasDnySG7di6rrQM4WNhMy8HCbOg2A/4dESe3ZkTEHcAjkv4gaU7gKGBXSXdI2lXS/ZJGAUgaJmmSpEV7k3yzeg4WZkO3BnDb1BZGxMvA4cAFEbFORFwAnAvsXlZ5J3BnRDzZeErNZpCDhVlvnAHsWV5/CDizh2kxq+VgYTZ0dwPrTc8bIuIR4HFJmwMbAlc0kTCzTnGwMBu6a4G5JO3TmiFpfWCZyjrPAQsMeN9pZHXUjyPi1cZTaTYEDhZmQ1SeUvguYMvSdfZu4Ejg0cpq1wGrtRq4y7yJwPy4CspmAh4byqxHytMQvxURm/Q6LWZ1/PAjsx6QdCiwH1N6RJn1NZcszMysltsszMysloOFmZnVcrAwM7NaDhZmZlbLwcLMzGo5WJiZWa3/DxUmlV0vrfd+AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "aggregations = {'target':['mean', 'count']}\n",
     "\n",
@@ -204,9 +470,216 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>channelGrouping</th>\n",
+       "      <th>date</th>\n",
+       "      <th>fullVisitorId</th>\n",
+       "      <th>visitNumber</th>\n",
+       "      <th>browser</th>\n",
+       "      <th>deviceCategory</th>\n",
+       "      <th>isMobile</th>\n",
+       "      <th>operatingSystem</th>\n",
+       "      <th>continent</th>\n",
+       "      <th>metro</th>\n",
+       "      <th>...</th>\n",
+       "      <th>weekday</th>\n",
+       "      <th>visitHour</th>\n",
+       "      <th>totalVisits</th>\n",
+       "      <th>country_United States</th>\n",
+       "      <th>city_New York</th>\n",
+       "      <th>city_Chicago</th>\n",
+       "      <th>city_Austin</th>\n",
+       "      <th>city_Seattle</th>\n",
+       "      <th>city_Palo Alto</th>\n",
+       "      <th>city_Toronto</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Organic Search</td>\n",
+       "      <td>2016-09-02</td>\n",
+       "      <td>1131660440785968503</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Chrome</td>\n",
+       "      <td>desktop</td>\n",
+       "      <td>False</td>\n",
+       "      <td>Windows</td>\n",
+       "      <td>Asia</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>17</td>\n",
+       "      <td>1</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Organic Search</td>\n",
+       "      <td>2016-09-02</td>\n",
+       "      <td>377306020877927890</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Firefox</td>\n",
+       "      <td>desktop</td>\n",
+       "      <td>False</td>\n",
+       "      <td>Macintosh</td>\n",
+       "      <td>Oceania</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Organic Search</td>\n",
+       "      <td>2016-09-02</td>\n",
+       "      <td>3895546263509774583</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Chrome</td>\n",
+       "      <td>desktop</td>\n",
+       "      <td>False</td>\n",
+       "      <td>Windows</td>\n",
+       "      <td>Europe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Organic Search</td>\n",
+       "      <td>2016-09-02</td>\n",
+       "      <td>4763447161404445595</td>\n",
+       "      <td>1</td>\n",
+       "      <td>UC Browser</td>\n",
+       "      <td>desktop</td>\n",
+       "      <td>False</td>\n",
+       "      <td>Linux</td>\n",
+       "      <td>Asia</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Organic Search</td>\n",
+       "      <td>2016-09-02</td>\n",
+       "      <td>27294437909732085</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Chrome</td>\n",
+       "      <td>mobile</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Android</td>\n",
+       "      <td>Europe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>15</td>\n",
+       "      <td>2</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 51 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  channelGrouping       date        fullVisitorId  visitNumber     browser  \\\n",
+       "0  Organic Search 2016-09-02  1131660440785968503            1      Chrome   \n",
+       "1  Organic Search 2016-09-02   377306020877927890            1     Firefox   \n",
+       "2  Organic Search 2016-09-02  3895546263509774583            1      Chrome   \n",
+       "3  Organic Search 2016-09-02  4763447161404445595            1  UC Browser   \n",
+       "4  Organic Search 2016-09-02    27294437909732085            2      Chrome   \n",
+       "\n",
+       "  deviceCategory  isMobile operatingSystem continent metro     ...       \\\n",
+       "0        desktop     False         Windows      Asia   NaN     ...        \n",
+       "1        desktop     False       Macintosh   Oceania   NaN     ...        \n",
+       "2        desktop     False         Windows    Europe   NaN     ...        \n",
+       "3        desktop     False           Linux      Asia   NaN     ...        \n",
+       "4         mobile      True         Android    Europe   NaN     ...        \n",
+       "\n",
+       "  weekday visitHour totalVisits country_United States city_New York  \\\n",
+       "0       4        17           1                 False         False   \n",
+       "1       4         7           1                 False         False   \n",
+       "2       4         3           1                 False         False   \n",
+       "3       4         7           1                 False         False   \n",
+       "4       4        15           2                 False         False   \n",
+       "\n",
+       "  city_Chicago city_Austin city_Seattle city_Palo Alto city_Toronto  \n",
+       "0        False       False        False          False        False  \n",
+       "1        False       False        False          False        False  \n",
+       "2        False       False        False          False        False  \n",
+       "3        False       False        False          False        False  \n",
+       "4        False       False        False          False        False  \n",
+       "\n",
+       "[5 rows x 51 columns]"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "check = ohe_explicit(train)\n",
     "check.head()  "
@@ -215,9 +688,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "kaggle_env",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "kaggle_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -229,7 +702,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Checking whether it makes sense to naively predict 0 revenue for users with a single visit (that was not a purchase)